### PR TITLE
Fetch a copy as a regular byte string

### DIFF
--- a/pysoundfile.py
+++ b/pysoundfile.py
@@ -433,7 +433,7 @@ class SoundFile(object):
         data = ffi.new(formats[format], frames*self.channels)
         read = readers[format](self._file, data, frames)
         self._handle_error()
-        np_data = np.fromstring(ffi.buffer(data), dtype=format,
+        np_data = np.fromstring(ffi.buffer(data)[:], dtype=format,
                                 count=read*self.channels)
         return np.reshape(np_data, (read, self.channels))
 


### PR DESCRIPTION
At least on PyPy, `np.fromstring` doesn't like being passed a buffer.
