### PR TITLE
Several changes based on #18

### DIFF
--- a/pysoundfile.py
+++ b/pysoundfile.py
@@ -131,205 +131,119 @@ _SUBMASK  = 0x0000FFFF
 _TYPEMASK = 0x0FFF0000
 _ENDMASK  = 0x30000000
 
-_TITLE       = 0x01
-_COPYRIGHT   = 0x02
-_SOFTWARE    = 0x03
-_ARTIST      = 0x04
-_COMMENT     = 0x05
-_DATE        = 0x06
-_ALBUM       = 0x07
-_LICENSE     = 0x08
-_TRACKNUMBER = 0x09
-_GENRE       = 0x10
-
 _GET_FORMAT_INFO          = 0x1028
 _GET_FORMAT_MAJOR_COUNT   = 0x1030
 _GET_FORMAT_MAJOR         = 0x1031
 _GET_FORMAT_SUBTYPE_COUNT = 0x1032
 _GET_FORMAT_SUBTYPE       = 0x1033
 
-
-class _Mode(int):
-    _modes = {}
-
-    @classmethod
-    def _define(cls, id, longname, shortname):
-        cls._modes[id] = longname, shortname.upper()
-        return _Mode(longname)
-
-    def __new__(cls, value):
-        if isinstance(value, str):
-            for k, v in cls._modes.items():
-                if value.upper() in v:
-                    value = k
-                    break
-            else:
-                raise ValueError("Invalid mode string: %s" % repr(value))
-        elif not isinstance(value, _Mode):
-            raise TypeError("Invalid mode")
-        return super(_Mode, cls).__new__(cls, value)
-
-    def __repr__(self):
-        return self._modes[self][0]
-
-    __str__ = __repr__
-
-READ  = _Mode._define(0x10, 'READ',  'r')
-WRITE = _Mode._define(0x20, 'WRITE', 'w')
-RDWR  = _Mode._define(0x30, 'RDWR', 'rw')
-
-
-class _Format(int):
-    def __new__(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, str):
-            value = globals().get(value.upper())
-            if not isinstance(value, _Format):
-                raise ValueError("Invalid format string: %s" % repr(value))
-        return super(_Format, cls).__new__(cls, value)
-
-    def __repr__(self):
-        for k, v in globals().items():
-            if v == self and isinstance(v, _Format):
-                return k
-        return super(_Format, self).__repr__()
-
-    __str__ = __repr__
-
-# major formats:
-
-WAV   = _Format(0x010000)  # Microsoft WAV format (little endian default).
-AIFF  = _Format(0x020000)  # Apple/SGI AIFF format (big endian).
-AU    = _Format(0x030000)  # Sun/NeXT AU format (big endian).
-RAW   = _Format(0x040000)  # RAW PCM data.
-PAF   = _Format(0x050000)  # Ensoniq PARIS file format.
-SVX   = _Format(0x060000)  # Amiga IFF / SVX8 / SV16 format.
-NIST  = _Format(0x070000)  # Sphere NIST format.
-VOC   = _Format(0x080000)  # VOC files.
-IRCAM = _Format(0x0A0000)  # Berkeley/IRCAM/CARL
-W64   = _Format(0x0B0000)  # Sonic Foundrys 64 bit RIFF/WAV
-MAT4  = _Format(0x0C0000)  # Matlab (tm) V4.2 / GNU Octave 2.0
-MAT5  = _Format(0x0D0000)  # Matlab (tm) V5.0 / GNU Octave 2.1
-PVF   = _Format(0x0E0000)  # Portable Voice Format
-XI    = _Format(0x0F0000)  # Fasttracker 2 Extended Instrument
-HTK   = _Format(0x100000)  # HMM Tool Kit format
-SDS   = _Format(0x110000)  # Midi Sample Dump Standard
-AVR   = _Format(0x120000)  # Audio Visual Research
-WAVEX = _Format(0x130000)  # MS WAVE with WAVEFORMATEX
-SD2   = _Format(0x160000)  # Sound Designer 2
-FLAC  = _Format(0x170000)  # FLAC lossless file format
-CAF   = _Format(0x180000)  # Core Audio File format
-WVE   = _Format(0x190000)  # Psion WVE format
-OGG   = _Format(0x200000)  # Xiph OGG container
-MPC2K = _Format(0x210000)  # Akai MPC 2000 sampler
-RF64  = _Format(0x220000)  # RF64 WAV file
-
-# subtypes:
-
-PCM_S8    = _Format(0x0001)  # Signed 8 bit data
-PCM_16    = _Format(0x0002)  # Signed 16 bit data
-PCM_24    = _Format(0x0003)  # Signed 24 bit data
-PCM_32    = _Format(0x0004)  # Signed 32 bit data
-PCM_U8    = _Format(0x0005)  # Unsigned 8 bit data (WAV and RAW only)
-FLOAT     = _Format(0x0006)  # 32 bit float data
-DOUBLE    = _Format(0x0007)  # 64 bit float data
-ULAW      = _Format(0x0010)  # U-Law encoded.
-ALAW      = _Format(0x0011)  # A-Law encoded.
-IMA_ADPCM = _Format(0x0012)  # IMA ADPCM.
-MS_ADPCM  = _Format(0x0013)  # Microsoft ADPCM.
-GSM610    = _Format(0x0020)  # GSM 6.10 encoding.
-VOX_ADPCM = _Format(0x0021)  # OKI / Dialogix ADPCM
-G721_32   = _Format(0x0030)  # 32kbs G721 ADPCM encoding.
-G723_24   = _Format(0x0031)  # 24kbs G723 ADPCM encoding.
-G723_40   = _Format(0x0032)  # 40kbs G723 ADPCM encoding.
-DWVW_12   = _Format(0x0040)  # 12 bit Delta Width Variable Word encoding.
-DWVW_16   = _Format(0x0041)  # 16 bit Delta Width Variable Word encoding.
-DWVW_24   = _Format(0x0042)  # 24 bit Delta Width Variable Word encoding.
-DWVW_N    = _Format(0x0043)  # N bit Delta Width Variable Word encoding.
-DPCM_8    = _Format(0x0050)  # 8 bit differential PCM (XI only)
-DPCM_16   = _Format(0x0051)  # 16 bit differential PCM (XI only)
-VORBIS    = _Format(0x0060)  # Xiph Vorbis encoding.
-
-# endian-ness:
-
-FILE   = _Format(0x00000000)  # Default file endian-ness.
-LITTLE = _Format(0x10000000)  # Force little endian-ness.
-BIG    = _Format(0x20000000)  # Force big endian-ness.
-CPU    = _Format(0x30000000)  # Force CPU endian-ness.
-
-_format_by_extension = {
-    'wav': WAV,
-    'aif': AIFF,
-    'aiff': AIFF,
-    'aifc': AIFF | FLOAT,
-    'au': AU,
-    'raw': RAW,
-    'paf': PAF,
-    'svx': SVX,
-    'nist': NIST,
-    'voc': VOC,
-    'ircam': IRCAM,
-    'w64': W64,
-    'mat4': MAT4,
-    'mat': MAT5,
-    'pvf': PVF,
-    'xi': XI,
-    'htk': HTK,
-    'sds': SDS,
-    'avr': AVR,
-    'wavex': WAVEX,
-    'sd2': SD2,
-    'flac': FLAC,
-    'caf': CAF,
-    'wve': WVE,
-    'ogg': OGG,
-    'oga': OGG,
-    'mpc2k': MPC2K,
-    'rf64': RF64,
-    'vox': RAW | VOX_ADPCM,
-}
-
-# see http://www.mega-nerd.com/libsndfile/ for supported subtypes
-_default_subtypes = {
-    WAV: PCM_16,
-    AIFF: PCM_16,
-    AU: PCM_16,
-    #RAW:  # subtype must be explicit!
-    PAF: PCM_16,
-    SVX: PCM_16,
-    NIST: PCM_16,
-    VOC: PCM_16,
-    IRCAM: PCM_16,
-    W64: PCM_16,
-    MAT4: DOUBLE,
-    MAT5: DOUBLE,
-    PVF: PCM_16,
-    XI: DPCM_16,
-    HTK: PCM_16,
-    #SDS:
-    #AVR:
-    WAVEX: PCM_16,
-    SD2: PCM_16,
-    FLAC: PCM_16,
-    CAF: PCM_16,
-    #WVE:
-    OGG: VORBIS,
-    #MPC2K:
-    #RF64:
+_open_modes = {
+    'r':  0x10,
+    'w':  0x20,
+    'rw': 0x30,
 }
 
 _str_types = {
-    'title': _TITLE,
-    'copyright': _COPYRIGHT,
-    'software': _SOFTWARE,
-    'artist': _ARTIST,
-    'comment': _COMMENT,
-    'date': _DATE,
-    'album': _ALBUM,
-    'license': _LICENSE,
-    'tracknumber': _TRACKNUMBER,
-    'genre': _GENRE
+    'title':       0x01,
+    'copyright':   0x02,
+    'software':    0x03,
+    'artist':      0x04,
+    'comment':     0x05,
+    'date':        0x06,
+    'album':       0x07,
+    'license':     0x08,
+    'tracknumber': 0x09,
+    'genre':       0x10,
+}
+
+_formats = {
+    'WAV':   0x010000,  # Microsoft WAV format (little endian default).
+    'AIFF':  0x020000,  # Apple/SGI AIFF format (big endian).
+    'AU':    0x030000,  # Sun/NeXT AU format (big endian).
+    'RAW':   0x040000,  # RAW PCM data.
+    'PAF':   0x050000,  # Ensoniq PARIS file format.
+    'SVX':   0x060000,  # Amiga IFF / SVX8 / SV16 format.
+    'NIST':  0x070000,  # Sphere NIST format.
+    'VOC':   0x080000,  # VOC files.
+    'IRCAM': 0x0A0000,  # Berkeley/IRCAM/CARL
+    'W64':   0x0B0000,  # Sonic Foundry's 64 bit RIFF/WAV
+    'MAT4':  0x0C0000,  # Matlab (tm) V4.2 / GNU Octave 2.0
+    'MAT5':  0x0D0000,  # Matlab (tm) V5.0 / GNU Octave 2.1
+    'PVF':   0x0E0000,  # Portable Voice Format
+    'XI':    0x0F0000,  # Fasttracker 2 Extended Instrument
+    'HTK':   0x100000,  # HMM Tool Kit format
+    'SDS':   0x110000,  # Midi Sample Dump Standard
+    'AVR':   0x120000,  # Audio Visual Research
+    'WAVEX': 0x130000,  # MS WAVE with WAVEFORMATEX
+    'SD2':   0x160000,  # Sound Designer 2
+    'FLAC':  0x170000,  # FLAC lossless file format
+    'CAF':   0x180000,  # Core Audio File format
+    'WVE':   0x190000,  # Psion WVE format
+    'OGG':   0x200000,  # Xiph OGG container
+    'MPC2K': 0x210000,  # Akai MPC 2000 sampler
+    'RF64':  0x220000,  # RF64 WAV file
+}
+
+_subtypes = {
+    'PCM_S8':    0x0001,  # Signed 8 bit data
+    'PCM_16':    0x0002,  # Signed 16 bit data
+    'PCM_24':    0x0003,  # Signed 24 bit data
+    'PCM_32':    0x0004,  # Signed 32 bit data
+    'PCM_U8':    0x0005,  # Unsigned 8 bit data (WAV and RAW only)
+    'FLOAT':     0x0006,  # 32 bit float data
+    'DOUBLE':    0x0007,  # 64 bit float data
+    'ULAW':      0x0010,  # U-Law encoded.
+    'ALAW':      0x0011,  # A-Law encoded.
+    'IMA_ADPCM': 0x0012,  # IMA ADPCM.
+    'MS_ADPCM':  0x0013,  # Microsoft ADPCM.
+    'GSM610':    0x0020,  # GSM 6.10 encoding.
+    'VOX_ADPCM': 0x0021,  # OKI / Dialogix ADPCM
+    'G721_32':   0x0030,  # 32kbs G721 ADPCM encoding.
+    'G723_24':   0x0031,  # 24kbs G723 ADPCM encoding.
+    'G723_40':   0x0032,  # 40kbs G723 ADPCM encoding.
+    'DWVW_12':   0x0040,  # 12 bit Delta Width Variable Word encoding.
+    'DWVW_16':   0x0041,  # 16 bit Delta Width Variable Word encoding.
+    'DWVW_24':   0x0042,  # 24 bit Delta Width Variable Word encoding.
+    'DWVW_N':    0x0043,  # N bit Delta Width Variable Word encoding.
+    'DPCM_8':    0x0050,  # 8 bit differential PCM (XI only)
+    'DPCM_16':   0x0051,  # 16 bit differential PCM (XI only)
+    'VORBIS':    0x0060,  # Xiph Vorbis encoding.
+}
+
+_endians = {
+    'FILE':   0x00000000,  # Default file endian-ness.
+    'LITTLE': 0x10000000,  # Force little endian-ness.
+    'BIG':    0x20000000,  # Force big endian-ness.
+    'CPU':    0x30000000,  # Force CPU endian-ness.
+}
+
+# libsndfile doesn't specify default subtypes, these are somehow arbitrary:
+_default_subtypes = {
+    'WAV':   'PCM_16',
+    'AIFF':  'PCM_16',
+    'AU':    'PCM_16',
+    #'RAW':  # subtype must be explicit!
+    'PAF':   'PCM_16',
+    'SVX':   'PCM_16',
+    'NIST':  'PCM_16',
+    'VOC':   'PCM_16',
+    'IRCAM': 'PCM_16',
+    'W64':   'PCM_16',
+    'MAT4':  'DOUBLE',
+    'MAT5':  'DOUBLE',
+    'PVF':   'PCM_16',
+    'XI':    'DPCM_16',
+    'HTK':   'PCM_16',
+    'SDS':   'PCM_16',
+    'AVR':   'PCM_16',
+    'WAVEX': 'PCM_16',
+    'SD2':   'PCM_16',
+    'FLAC':  'PCM_16',
+    'CAF':   'PCM_16',
+    'WVE':   'ALAW',
+    'OGG':   'VORBIS',
+    'MPC2K': 'PCM_16',
+    'RF64':  'PCM_16',
 }
 
 _snd = _ffi.dlopen('sndfile')
@@ -342,7 +256,7 @@ class SoundFile(object):
     Each SoundFile opens one sound file on the disk. This sound file
     has a specific samplerate, data format and a set number of
     channels. Each sound file can be opened with one of the modes
-    READ/WRITE/RDWR. Note that RDWR is unsupported for some formats.
+    'r'/'w'/'rw'. Note that 'rw' is unsupported for some formats.
 
     Data can be written to the file using write(), or read from the
     file using read(). Every read and write operation starts at a
@@ -370,28 +284,24 @@ class SoundFile(object):
 
     """
 
-    def __init__(self, file, mode=READ, sample_rate=None, channels=None,
+    def __init__(self, file, mode='r', sample_rate=None, channels=None,
                  subtype=None, endian=None, format=None, closefd=True):
         """Open a new SoundFile.
 
-        If a file is opened with mode READ (the default) or RDWR,
+        If a file is opened with mode 'r' (the default) or 'rw',
         no sample_rate, channels or file format need to be given. If a
-        file is opened with mode WRITE, you must provide a sample_rate,
+        file is opened with mode 'w', you must provide a sample_rate,
         a number of channels, and a file format. An exception is the
         RAW data format, which requires these data points for reading
         as well.
 
-        Instead of the library constants READ/WRITE/RDWR you can also
-        use the (case-insensitive) strings 'r'/'w'/'rw' or
-        'READ'/'WRITE'/'RDWR'.
-
-        File formats consist of three parts:
+        File formats consist of three case-insensitive strings:
          - a "major format" which is by default obtained from the
            extension of the file name (if known) and which can be
-           forced with the format argument (e.g. format=WAVEX).
-         - a "subtype", e.g. PCM_24. Most major formats have a default
+           forced with the format argument (e.g. format='WAVEX').
+         - a "subtype", e.g. 'PCM_24'. Most major formats have a default
            subtype which is used if no subtype is specified.
-         - an endian-ness: FILE (default), LITTLE, BIG or CPU.
+         - an "endian-ness": 'FILE' (default), 'LITTLE', 'BIG' or 'CPU'.
            In most cases this doesn't have to be specified.
 
         The functions available_formats() and available_subtypes() can
@@ -399,60 +309,45 @@ class SoundFile(object):
         subtypes, respectively.
 
         """
-        for arg in file, sample_rate, channels:
-            if isinstance(arg, _Format):
-                raise TypeError("%s is not allowed here" % repr(arg))
-
-        mode = _Mode(mode)
+        try:
+            self._mode = mode
+            mode_int = _open_modes[self._mode]
+        except KeyError:
+            raise ValueError("Invalid mode: %s" % repr(mode))
 
         original_format = format
         if format is None:
-            ext = getattr(file, 'name', file if isinstance(file, str) else ""
-                          ).rsplit('.', 1)[-1]
-            format = _format_by_extension.get(ext.lower(), 0x0)
-        else:
-            format = _Format(format)
+            filename = getattr(file, 'name', file)
+            format = str(filename).rsplit('.', 1)[-1].upper()
+            if self.mode == 'w' and format not in _formats:
+                raise TypeError(
+                    "No format specified and unable to get format from "
+                    "file extension: %s" % repr(filename))
 
         self._info = _ffi.new("SF_INFO*")
-        if mode == WRITE or format == RAW:
+        if self.mode == 'w' or str(format).upper() == 'RAW':
             if sample_rate is None:
                 raise TypeError("sample_rate must be specified")
             self._info.samplerate = sample_rate
             if channels is None:
                 raise TypeError("channels must be specified")
             self._info.channels = channels
-
-            subtype = _Format(subtype) or _default_subtypes.get(format, 0x0)
-            endian = _Format(endian) or FILE
-
-            format = format | subtype | endian
-
-            if not format:
-                raise ValueError("No format specified")
-            if not format & _TYPEMASK:
-                raise ValueError("Invalid format")
-            if not format & _SUBMASK:
-                raise ValueError("Invalid subtype")
-            if not format & _ENDMASK and endian != FILE:
-                raise ValueError("Invalid endian-ness")
-            if not format_check(format):
-                raise ValueError(
-                    "Invalid combination of format, subtype and endian")
-            self._info.format = format
+            self._info.format = _format_int(format, subtype, endian)
         else:
-            if [sample_rate, channels, subtype, endian, original_format] \
-                    != [None] * 5:
-                raise TypeError("Only allowed if mode=WRITE or format=RAW: "
-                                "sample_rate, channels, format, subtype, "
-                                "endian")
+            if [sample_rate, channels, original_format, subtype, endian] != \
+                    [None] * 5:
+                raise TypeError("Only allowed if mode='w' or format='RAW': "
+                                "sample_rate, channels, "
+                                "format, subtype, endian")
 
         self._name = file
         if isinstance(file, str):
             file = _ffi.new('char[]', file.encode())
-            self._file = _snd.sf_open(file, mode, self._info)
+            self._file = _snd.sf_open(file, mode_int, self._info)
         elif isinstance(file, int):
-            self._file = _snd.sf_open_fd(file, mode, self._info, closefd)
+            self._file = _snd.sf_open_fd(file, mode_int, self._info, closefd)
         else:
+            # Note: readinto() is not checked
             for attr in ('seek', 'read', 'write', 'tell'):
                 if not hasattr(file, attr):
                     msg = "file must be a filename, a file descriptor or " \
@@ -462,22 +357,25 @@ class SoundFile(object):
             # Note: the callback functions in _vio must be kept alive!
             self._vio = self._init_vio(file)
             vio = _ffi.new("SF_VIRTUAL_IO*", self._vio)
-            self._file = _snd.sf_open_virtual(vio, mode, self._info, _ffi.NULL)
+            self._file = _snd.sf_open_virtual(vio, mode_int, self._info,
+                                              _ffi.NULL)
             self._name = str(file)
 
         self._handle_error()
-        self._mode = mode
+
 
     name = property(lambda self: self._name)
     mode = property(lambda self: self._mode)
     frames = property(lambda self: self._info.frames)
     sample_rate = property(lambda self: self._info.samplerate)
     channels = property(lambda self: self._info.channels)
-    format = property(lambda self: _Format(self._info.format & _TYPEMASK))
-    subtype = property(lambda self: _Format(self._info.format & _SUBMASK))
-    endian = property(lambda self: _Format(self._info.format & _ENDMASK))
-    format_string = property(lambda self: get_format_string(self.format))
-    subtype_string = property(lambda self: get_format_string(self.subtype))
+    format = property(lambda self: _format_str(self._info.format & _TYPEMASK))
+    subtype = property(lambda self: _format_str(self._info.format & _SUBMASK))
+    endian = property(lambda self: _format_str(self._info.format & _ENDMASK))
+    format_info = property(
+        lambda self: _format_info(self._info.format & _TYPEMASK)[1])
+    subtype_info = property(
+        lambda self: _format_info(self._info.format & _SUBMASK)[1])
     sections = property(lambda self: self._info.sections)
     seekable = property(lambda self: self._info.seekable == 1)
     closed = property(lambda self: self._file is None)
@@ -573,8 +471,8 @@ class SoundFile(object):
         # access text data in the sound file through properties
         if name in _str_types:
             self._check_if_closed()
-            if self.mode == READ:
-                raise RuntimeError("Can not change %s of file in READ mode" %
+            if self.mode == 'r':
+                raise RuntimeError("Can not change %s of file in read mode" %
                                    name)
             data = _ffi.new('char[]', value.encode())
             err = _snd.sf_set_string(self._file, _str_types[name], data)
@@ -587,12 +485,9 @@ class SoundFile(object):
         if name in _str_types:
             self._check_if_closed()
             data = _snd.sf_get_string(self._file, _str_types[name])
-            if data == _ffi.NULL:
-                return ""
-            else:
-                return _ffi.string(data).decode()
+            return _ffi.string(data).decode() if data else ""
         else:
-            raise AttributeError("SoundFile has no attribute %s" % name)
+            raise AttributeError("SoundFile has no attribute %s" % repr(name))
 
     def __len__(self):
         return self.frames
@@ -618,10 +513,10 @@ class SoundFile(object):
                     "SoundFile can only be accessed in one or two dimensions")
             frame, second_frame = frame
         start, stop = self._get_slice_bounds(frame)
-        curr = self.seek(0, SEEK_CUR | READ)
-        self.seek(start, SEEK_SET | READ)
+        curr = self.seek(0, SEEK_CUR, 'r')
+        self.seek(start, SEEK_SET, 'r')
         data = self.read(stop - start)
-        self.seek(curr, SEEK_SET | READ)
+        self.seek(curr, SEEK_SET, 'r')
         if second_frame:
             return data[(slice(None), second_frame)]
         else:
@@ -631,17 +526,17 @@ class SoundFile(object):
         # access the file as if it where a one-dimensional Numpy
         # array. Data must be in the form (frames x channels).
         # Both open slice bounds and negative values are allowed.
-        if self.mode == READ:
-            raise RuntimeError("Cannot write to file opened in READ mode")
+        if self.mode == 'r':
+            raise RuntimeError("Cannot write to file opened in read mode")
         start, stop = self._get_slice_bounds(frame)
         if stop - start != len(data):
             raise IndexError(
                 "Could not fit data of length %i into slice of length %i" %
                 (len(data), stop - start))
-        curr = self.seek(0, SEEK_CUR | WRITE)
-        self.seek(start, SEEK_SET | WRITE)
+        curr = self.seek(0, SEEK_CUR, 'w')
+        self.seek(start, SEEK_SET, 'w')
         self.write(data)
-        self.seek(curr, SEEK_SET | WRITE)
+        self.seek(curr, SEEK_SET, 'w')
         return data
 
     def flush(self):
@@ -658,7 +553,7 @@ class SoundFile(object):
             self._file = None
             self._handle_error_number(err)
 
-    def seek(self, frames, whence=SEEK_SET):
+    def seek(self, frames, whence=SEEK_SET, which=None):
         """Set the read and/or write position.
 
         By default (whence=SEEK_SET), frames are counted from the
@@ -666,9 +561,10 @@ class SoundFile(object):
         (positive and negative values are allowed).
         SEEK_END seeks from the end (use negative values).
 
-        In RDWR mode, the whence argument can be combined (using
-        logical or) with READ or WRITE in order to set only the read
-        or write position, respectively (e.g. SEEK_SET | WRITE).
+        If the file is opened in 'rw' mode, both read and write position
+        are set to the same value by default.
+        Use which='r' or which='w' to set only the read position or the
+        write position, respectively.
 
         To set the read/write position to the beginning of the file,
         use seek(0), to set it to right after the last frame,
@@ -676,8 +572,13 @@ class SoundFile(object):
 
         Returns the new absolute read position in frames or a negative
         value on error.
+
         """
         self._check_if_closed()
+        if which in ('r', 'w'):
+            whence |= _open_modes[which]
+        elif which is not None:
+            raise ValueError("Invalid which: %s" % repr(which))
         return _snd.sf_seek(self._file, frames, whence)
 
     def read(self, frames=-1, dtype='float64'):
@@ -695,8 +596,8 @@ class SoundFile(object):
 
         """
         self._check_if_closed()
-        if self.mode == WRITE:
-            raise RuntimeError("Cannot read from file opened in WRITE mode")
+        if self.mode == 'w':
+            raise RuntimeError("Cannot read from file opened in write mode")
         formats = {
             _np.float64: 'double[]',
             _np.float32: 'float[]',
@@ -713,7 +614,7 @@ class SoundFile(object):
         if dtype.type not in formats:
             raise ValueError("Can only read int16, int32, float32 and float64")
         if frames < 0:
-            curr = self.seek(0, SEEK_CUR | READ)
+            curr = self.seek(0, SEEK_CUR, 'r')
             frames = self.frames - curr
         data = _ffi.new(formats[dtype.type], frames*self.channels)
         read = readers[dtype.type](self._file, data, frames)
@@ -734,8 +635,8 @@ class SoundFile(object):
 
         """
         self._check_if_closed()
-        if self.mode == READ:
-            raise RuntimeError("Cannot write to file opened in READ mode")
+        if self.mode == 'r':
+            raise RuntimeError("Cannot write to file opened in read mode")
         formats = {
             _np.float64: 'double*',
             _np.float32: 'float*',
@@ -757,9 +658,9 @@ class SoundFile(object):
                                       len(data))
         self._handle_error()
 
-        curr = self.seek(0, SEEK_CUR | WRITE)
-        self._info.frames = self.seek(0, SEEK_END | WRITE)
-        self.seek(curr, SEEK_SET | WRITE)
+        curr = self.seek(0, SEEK_CUR, 'w')
+        self._info.frames = self.seek(0, SEEK_END, 'w')
+        self.seek(curr, SEEK_SET, 'w')
 
         return written
 
@@ -794,7 +695,7 @@ def read(file, frames=None, start=None, stop=None, **kwargs):
     read_kwargs = {}
     if 'dtype' in kwargs:
         read_kwargs['dtype'] = kwargs.pop('dtype')
-    with SoundFile(file, READ, **kwargs) as f:
+    with SoundFile(file, 'r', **kwargs) as f:
         start, stop, _ = slice(start, stop).indices(f.frames)
         if frames is None:
             frames = max(0, stop - start)
@@ -815,7 +716,7 @@ def write(data, file, sample_rate, *args, **kwargs):
     Example usage:
 
         import pysoundfile as sf
-        sf.write(myarray, 'myfile.wav', 44100, sf.PCM_24)
+        sf.write(myarray, 'myfile.wav', 44100, 'PCM_24')
 
     """
     data = _np.asarray(data)
@@ -826,55 +727,97 @@ def write(data, file, sample_rate, *args, **kwargs):
     else:
         raise RuntimeError("Only one- and two-dimensional arrays are allowed")
     frames = data.shape[0]
-    with SoundFile(file, WRITE, sample_rate, channels, *args, **kwargs) as f:
+    with SoundFile(file, 'w', sample_rate, channels, *args, **kwargs) as f:
         written = f.write(data)
     if frames != written:
         raise RuntimeError("Only %d of %d frames were written" % (written,
                                                                   frames))
 
 
-def _get_format_info(format, format_flag=_GET_FORMAT_INFO):
-    # Return the ID and name of a given format.
+def default_subtype(format):
+    """Return default subtype for given format."""
+    return _default_subtypes.get(str(format).upper())
+
+
+def _format_int(format, subtype, endian):
+    # Return numeric format ID for given format|subtype|endian combo
+    try:
+        result = _formats[str(format).upper()]
+    except KeyError:
+        raise ValueError("Invalid format string: %s" % repr(format))
+    if subtype is None:
+        subtype = default_subtype(format)
+        if subtype is None:
+            raise TypeError(
+                "No default subtype for major format %s" % repr(format))
+    try:
+        result |= _subtypes[str(subtype).upper()]
+    except KeyError:
+        raise ValueError("Invalid subtype string: %s" % repr(subtype))
+    try:
+        result |= _endians[str(endian).upper()
+                           if endian is not None else 'FILE']
+    except KeyError:
+        raise ValueError("Invalid endian-ness: %s" % repr(endian))
+
+    info = _ffi.new("SF_INFO*")
+    info.format = result
+    info.channels = 1
+    if _snd.sf_format_check(info) == _FALSE:
+        raise ValueError(
+            "Invalid combination of format, subtype and endian")
+    return result
+
+
+def format_check(format, subtype=None, endian=None):
+    """Check if the combination of format/subtype/endian is valid."""
+    try:
+        return bool(_format_int(format, subtype, endian))
+    except (ValueError, TypeError):
+        return False
+
+
+def _format_str(format_int):
+    # Return the string representation of a given numeric format
+    for dictionary in _formats, _subtypes, _endians:
+        for k, v in dictionary.items():
+            if v == format_int:
+                return k
+    return hex(format_int)
+
+
+def _format_info(format_int, format_flag=_GET_FORMAT_INFO):
+    # Return the ID and short description of a given format.
     format_info = _ffi.new("struct SF_FORMAT_INFO*")
-    format_info.format = format
+    format_info.format = format_int
     _snd.sf_command(_ffi.NULL, format_flag, format_info,
                     _ffi.sizeof("SF_FORMAT_INFO"))
-    return (_Format(format_info.format),
-            _ffi.string(format_info.name).decode() if format_info.name else "")
+    name = format_info.name
+    return (_format_str(format_info.format),
+            _ffi.string(name).decode() if name else "")
 
 
 def _available_formats_helper(count_flag, format_flag):
+    # Generator function used in available_formats() and available_subtypes()
     count = _ffi.new("int*")
     _snd.sf_command(_ffi.NULL, count_flag, count, _ffi.sizeof("int"))
-    count = count[0]
-    return dict(_get_format_info(f, format_flag) for f in range(count))
+    for format_int in range(count[0]):
+        yield _format_info(format_int, format_flag)
 
 
 def available_formats():
-    """Return a list of available major formats."""
-    return _available_formats_helper(_GET_FORMAT_MAJOR_COUNT,
-                                     _GET_FORMAT_MAJOR)
+    """Return a dictionary of available major formats."""
+    return dict(_available_formats_helper(_GET_FORMAT_MAJOR_COUNT,
+                                          _GET_FORMAT_MAJOR))
 
 
-def available_subtypes():
-    """Return a list of available subtypes."""
-    return _available_formats_helper(_GET_FORMAT_SUBTYPE_COUNT,
-                                     _GET_FORMAT_SUBTYPE)
+def available_subtypes(format=None):
+    """Return a dictionary of available subtypes.
 
-
-def get_format_string(format):
-    """Return the name of a given major format or subtype."""
-    return _get_format_info(format)[1]
-
-
-def format_check(format):
-    """Check if the given format is supported.
-
-    format must be a combination (with logical OR) of major format,
-    subtype and (optional) endian-ness.
+    If format is specified, only compatible subtypes are returned.
 
     """
-    info = _ffi.new("SF_INFO*")
-    info.format = format
-    info.channels = 1
-    return _snd.sf_format_check(info) == _TRUE
+    subtypes = _available_formats_helper(_GET_FORMAT_SUBTYPE_COUNT,
+                                         _GET_FORMAT_SUBTYPE)
+    return dict((subtype, name) for subtype, name in subtypes
+                if format is None or format_check(format, subtype))


### PR DESCRIPTION
This pull request contains most of the changes of #18, but with more documentation and hopefully with a little less noise.

I also fixed 2 bugs regarding the virtual IO feature (963c1fa and 4e068f3, see also #19), I hope I didn't make it worse.

In addition to #18, I included following features:
- `available_formats()` and `available_subtypes()` (88ab0ef)
- allow string arguments for format/subtype/endian (c3d0df7)
