### PR TITLE
read(): don't ignore frames if out is given?

### DIFF
--- a/pysoundfile.py
+++ b/pysoundfile.py
@@ -609,7 +609,7 @@ class SoundFile(object):
         ffi_type = _ffi_types[array.dtype]
         assert array.flags.c_contiguous
         assert array.dtype.itemsize == _ffi.sizeof(ffi_type)
-        assert array.size == frames * self.channels
+        assert array.size >= frames * self.channels
 
         func = getattr(_snd, funcname + ffi_type)
         ptr = _ffi.cast(ffi_type + '*', array.ctypes.data)
@@ -633,8 +633,8 @@ class SoundFile(object):
         one-dimensional array in this case.
 
         If out is specified, the data is written into the given NumPy
-        array.  In this case, the arguments frames, dtype and always_2d
-        are silently ignored!
+        array.  In this case, the arguments dtype and always_2d are
+        silently ignored!
 
         If there is less data left in the file than requested, the rest
         of the frames are filled with fill_value. If fill_value=None, a
@@ -658,7 +658,8 @@ class SoundFile(object):
                 shape = frames,
             out = _np.empty(shape, dtype, order='C')
         else:
-            frames = len(out)
+            if frames < 0 or frames > len(out):
+                frames = len(out)
             if not out.flags.c_contiguous:
                 raise ValueError("out must be C-contiguous")
 


### PR DESCRIPTION
We already discussed this in #37 and the current behavior is this:

If both `frames` and `out` are specified in `read()`, the value of `frames` is silently ignored (same with `dtype` and `always_2d`).

While implementing the `blocks()` feature (#35), however, I found that it may be better to change this behavior slightly.

What about not ignoring `frames`?

That would mean if `frames` is smaller than the length of `out`, it is taken into account, if it is larger, it would still be ignored.
This would be similar to the default Python indexing behavior, where an index larger than the maximum index is silently truncated to the maximum index.

`dtype` and `always_2d` would still be ignored.

Is this a bad idea?

I didn't add tests to not interfere with the py.test rewrite, but we should add some test cases for this afterwards.
