### PR TITLE
Virtual IO: allow write() to return None

### DIFF
--- a/pysoundfile.py
+++ b/pysoundfile.py
@@ -447,7 +447,11 @@ class SoundFile(object):
         def vio_write(ptr, count, user_data):
             buf = _ffi.buffer(ptr, count)
             data = buf[:]
-            return file.write(data)
+            written = file.write(data)
+            # write() returns None for file objects in Python <= 2.7:
+            if written is None:
+                written = count
+            return written
 
         @_ffi.callback("sf_vio_tell")
         def vio_tell(user_data):


### PR DESCRIPTION
from https://docs.python.org/2/tutorial/inputoutput.html:

> `f.write(string)` writes the contents of _string_ to the file, returning **None**.

Python 3 seems to create a [BufferedWriter](https://docs.python.org/3.4/library/io.html#io.BufferedWriter), which returns the number of bytes written.
