### PR TITLE
PyTest with coverage tests and proper gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ dist
 build
 PySoundFile.egg-info
 MANIFEST
+*.pyc
+delme.please
+.coverage
+.cache
+*.wav
+*.raw

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 pysoundfile
 cffi>=0.6
 numpy
+pytest
+pytest-cov
+pytest-pep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov-report term-missing --cov .


### PR DESCRIPTION
Not much but this improves the testing experience by
- Not tracking temporary stuff that was created during tests
- Creating a coverage statistic to see how much of the code is actually tested:
  
  ```
  ==================================================== test session starts ====================================================
  platform darwin -- Python 2.7.8 -- py-1.4.26 -- pytest-2.6.4
  plugins: cache, cov, pep8
  collected 147 items 
  
  tests/test_argspec.py ....
  tests/test_pysoundfile.py .....................................................................s.........................................................................
  -------------------------------------- coverage: platform darwin, python 2.7.8-final-0 --------------------------------------
  Name                     Stmts   Miss  Cover   Missing
  ------------------------------------------------------
  pysoundfile                360     31    91%   379, 463, 484-486, 502-505, 762-765, 772, 782, 887, 1037-1041, 1085, 1094, 1099, 1102, 1104, 1126, 1198, 1209, 1225-1228
  setup                       12     12     0%   2-16
  tests/test_argspec          48      0   100%   
  tests/test_pysoundfile     436      4    99%   404-407
  ------------------------------------------------------
  TOTAL                      856     47    95%  
  ```
