### PR TITLE
Change (or remove) requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-cffi>=0.6
-numpy


### PR DESCRIPTION
I'm not sure if `requirements.txt` is needed at all, but if we keep it we should consider changing it according to https://caremad.io/blog/setup-vs-requirement/.

If I understand this correctly, the file should only contain this:

```
# See https://caremad.io/blog/setup-vs-requirement/

-e .
```

I don't know if `pysoundfile` itself would be needed in addition to that ...
