### PR TITLE
Remove either frames property or __len__() from SoundFile

### DIFF
--- a/pysoundfile.py
+++ b/pysoundfile.py
@@ -691,8 +691,6 @@ class SoundFile(object):
     """The file name of the sound file."""
     mode = property(lambda self: self._mode)
     """The open mode the sound file was opened with."""
-    frames = property(lambda self: self._info.frames)
-    """The number of frames in the sound file."""
     samplerate = property(lambda self: self._info.samplerate)
     """The sample rate of the sound file."""
     channels = property(lambda self: self._info.channels)
@@ -752,7 +750,7 @@ class SoundFile(object):
             raise AttributeError("SoundFile has no attribute %s" % repr(name))
 
     def __len__(self):
-        return self.frames
+        return self._info.frames
 
     def __getitem__(self, frame):
         # access the file as if it where a Numpy array. The data is
@@ -1107,7 +1105,7 @@ class SoundFile(object):
     def _check_frames(self, frames, fill_value):
         # Check if frames is larger than the remaining frames in the file
         if self.seekable():
-            remaining_frames = self.frames - self.seek(0, SEEK_CUR)
+            remaining_frames = len(self) - self.seek(0, SEEK_CUR)
             if frames < 0 or (frames > remaining_frames
                               and fill_value is None):
                 frames = remaining_frames
@@ -1160,7 +1158,7 @@ class SoundFile(object):
         if frames >= 0 and stop is not None:
             raise TypeError("Only one of {frames, stop} may be used")
 
-        start, stop, _ = slice(start, stop).indices(self.frames)
+        start, stop, _ = slice(start, stop).indices(len(self))
         if stop < start:
             stop = start
         if frames < 0:

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -419,7 +419,6 @@ def test_file_attributes_in_read_mode(sf_stereo_r):
     if not isinstance(sf_stereo_r.name, int):
         assert sf_stereo_r.name == filename_stereo
     assert sf_stereo_r.mode == 'r'
-    assert sf_stereo_r.frames == len(data_stereo)
     assert sf_stereo_r.samplerate == 44100
     assert sf_stereo_r.channels == 2
     assert sf_stereo_r.format == 'WAV'
@@ -654,9 +653,9 @@ def test_read_raw_files_with_too_few_arguments_should_fail():
 def test_write_non_seekable_file():
     with sf.SoundFile(filename_new, 'w', 44100, 1, format='XI') as f:
         assert not f.seekable()
-        assert f.frames == 0
+        assert len(f) == 0
         f.write(data_mono)
-        assert f.frames == len(data_mono)
+        assert len(f) == len(data_mono)
 
         with pytest.raises(RuntimeError) as excinfo:
             f.seek(2)
@@ -664,7 +663,7 @@ def test_write_non_seekable_file():
 
     with sf.SoundFile(filename_new) as f:
         assert not f.seekable()
-        assert f.frames == len(data_mono)
+        assert len(f) == len(data_mono)
         data = f.read(3, dtype='int16')
         assert np.all(data == data_mono[:3])
         data = f.read(666, dtype='int16')


### PR DESCRIPTION
There should be only one obvious way to get the length of a sound file (according to the Zen of Python).

The question is, which one should we keep?

`len()` is idiomatic for getting the length of something, but `frames` is more explicit because it avoids misunderstandings regarding frames vs. samples vs. bytes.
`frames` is used multiple times as a function argument, but I don't know if this counts as an advantage or disadvantage for the `frames` property.
