### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+recursive-include doc *.py *.rst *.txt Makefile
+recursive-include tests *.py *.wav *.raw


### PR DESCRIPTION
This should at least contain

```
include LICENSE
```

Probably we should also include the documentation source:

```
include doc/conf.py
include doc/fake_numpy.py
include doc/fake_cffi.py
include doc/Makefile
include doc/requirements.txt
recursive-include doc *.rst
```
