### PR TITLE
More compact PDF documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -209,7 +209,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
   ('index', 'PySoundFile.tex', 'PySoundFile Documentation',
-   'Bastian Bechtold, Matthias Geier', 'manual'),
+   'Bastian Bechtold, Matthias Geier', 'howto'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
Currently, the [PDF docs](https://media.readthedocs.org/pdf/pysoundfile/latest/pysoundfile.pdf) have a lot of empty space.

If we use `'howto'` instead of `'manual'` in `latex_documents` in `doc/conf.py`, the size would shrink from 23 to 12 pages.
