### PR TITLE
Miscellaneous small changes

### DIFF
--- a/pysoundfile.py
+++ b/pysoundfile.py
@@ -489,9 +489,9 @@ def check_format(format, subtype=None, endian=None):
     Examples
     --------
     >>> import pysoundfile as sf
-    >>> sf.format_check('WAV', 'PCM_24')
+    >>> sf.check_format('WAV', 'PCM_24')
     True
-    >>> sf.format_check('FLAC', 'VORBIS')
+    >>> sf.check_format('FLAC', 'VORBIS')
     False
 
     """


### PR DESCRIPTION
- Change order of `format`, `subtype` and `endian` function arguments in `format_check`, to be consistent with `SoundFile.__init__` etc.
- Change function argument order of `blocks` so that `blocksize` comes before the `__init__` arguments. This would make the typical usage of this function easier.
- Change function name of `format_check` to `check_format`.
