### PR TITLE
Change classifiers in setup.py?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
     platforms='any',
     classifiers=[
         'Development Status :: 3 - Alpha',
-        'Environment :: Other Environment',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
Are those two really necessary:

```
'Environment :: Other Environment'
'Natural Language :: English'
```

?

If we mention

```
'Programming Language :: Python :: 3'
```

... we should also mention

```
Programming Language :: Python :: 2
```

... or

```
Programming Language :: Python :: 2.6
Programming Language :: Python :: 2.7
```

Also, if we mention

```
'Programming Language :: Python :: Implementation :: PyPy'
```

... we should probably also mention

```
Programming Language :: Python :: Implementation :: CPython
```
