### PR TITLE
Release 0.11.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,45 @@
+name: Python Package
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        python-version:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "pypy-3.7"
+          - "pypy-3.8"
+        architecture: ["x86", "x64"]
+        exclude:
+          - os: macos-10.15 # Can't compile Numpy for this implementation.
+            python-version: "pypy-3.7"
+          - os: macos-10.15
+            architecture: "x86"
+          - os: ubuntu-20.04
+            architecture: "x86"
+
+    steps:
+      - name: Install APT dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libsndfile1
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+      - name: Install requirements
+        run: pip install numpy pytest
+      - name: Install editable package
+        run: pip install --editable . --verbose
+      - name: Run tests
+        run: python -m pytest

--- a/README.rst
+++ b/README.rst
@@ -292,3 +292,17 @@ News
     - Improves performance of `blocks()` and `SoundFile.blocks()`.
     - Improves import time by using CFFI's out of line mode.
     - Adds a build script for building distributions.
+
+2022-02-16 V0.11.0 Bastian Bechtold:
+    Thank you, tennies, Hannes Helmholz, Christoph Boeddeker, Matt
+    Vollrath, Matthias Geier, Jacek Konieczny, Boris Verkhovskiy,
+    Jonas Haag, Eduardo Moguillansky, Panos Laganakos, Jarvy Jarvison,
+    Domingo Ramirez, Tim Chagnon, Kyle Benesch
+
+    - Adds binary wheels for macOS M1
+    - Improves compatibility with macOS, specifically for M1 machines
+    - Updates libsndfile to v1.0.31
+    - Adds get_strings method for retrieving all metadata at once
+    - Improves documentation, error messages and tests
+    - Displays length of very short files in samples
+    - Supports the file system path protocol (pathlib et al)

--- a/README.rst
+++ b/README.rst
@@ -297,7 +297,8 @@ News
     Thank you, tennies, Hannes Helmholz, Christoph Boeddeker, Matt
     Vollrath, Matthias Geier, Jacek Konieczny, Boris Verkhovskiy,
     Jonas Haag, Eduardo Moguillansky, Panos Laganakos, Jarvy Jarvison,
-    Domingo Ramirez, Tim Chagnon, Kyle Benesch, Fabian-Robert Stöter
+    Domingo Ramirez, Tim Chagnon, Kyle Benesch, Fabian-Robert Stöter,
+    Joe Todd
 
     - MP3 support
     - Adds binary wheels for macOS M1

--- a/README.rst
+++ b/README.rst
@@ -293,16 +293,17 @@ News
     - Improves import time by using CFFI's out of line mode.
     - Adds a build script for building distributions.
 
-2022-02-16 V0.11.0 Bastian Bechtold:
+2022-06-02 V0.11.0 Bastian Bechtold:
     Thank you, tennies, Hannes Helmholz, Christoph Boeddeker, Matt
     Vollrath, Matthias Geier, Jacek Konieczny, Boris Verkhovskiy,
     Jonas Haag, Eduardo Moguillansky, Panos Laganakos, Jarvy Jarvison,
-    Domingo Ramirez, Tim Chagnon, Kyle Benesch
+    Domingo Ramirez, Tim Chagnon, Kyle Benesch, Fabian-Robert Stöter
 
+    - MP3 support
     - Adds binary wheels for macOS M1
     - Improves compatibility with macOS, specifically for M1 machines
     - Fixes file descriptor open for binary wheels on Windows and Python 3.5+
-    - Updates libsndfile to v1.0.31
+    - Updates libsndfile to v1.1.0
     - Adds get_strings method for retrieving all metadata at once
     - Improves documentation, error messages and tests
     - Displays length of very short files in samples

--- a/README.rst
+++ b/README.rst
@@ -301,6 +301,7 @@ News
 
     - Adds binary wheels for macOS M1
     - Improves compatibility with macOS, specifically for M1 machines
+    - Fixes file descriptor open for binary wheels on Windows and Python 3.5+
     - Updates libsndfile to v1.0.31
     - Adds get_strings method for retrieving all metadata at once
     - Improves documentation, error messages and tests

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -6,18 +6,21 @@ architectures = dict(darwin=['x86_64', 'arm64'],
                      noplatform='noarch')
 
 def cleanup():
+    os.environ['PYSOUNDFILE_PLATFORM'] = ''
+    os.environ['PYSOUNDFILE_ARCHITECTURE'] = ''
     shutil.rmtree('build', ignore_errors=True)
+    shutil.rmtree('soundfile.egg-info', ignore_errors=True)
     try:
         os.remove('_soundfile.py')
     except:
         pass
 
 for platform, archs in architectures.items():
-    os.environ['PYSOUNDFILE_PLATFORM'] = platform
     for arch in archs:
+        os.environ['PYSOUNDFILE_PLATFORM'] = platform
         os.environ['PYSOUNDFILE_ARCHITECTURE'] = arch
+        os.system('python3 setup.py bdist_wheel')
         cleanup()
-        os.system('python setup.py bdist_wheel')
 
+os.system('python3 setup.py sdist')
 cleanup()
-os.system('python setup.py sdist')

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 
-architectures = dict(darwin=['64bit'],
+architectures = dict(darwin=['x86_64', 'arm64'],
                      win32=['32bit', '64bit'],
                      noplatform='noarch')
 

--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,9 @@ else:
             pythons = 'py2.py3'
             if platform == 'darwin':
                 if architecture0 == 'x86_64':
-                    oses = 'macosx-10.x-x86_64'
+                    oses = 'macosx_10_9_x86_64'
                 else:
-                    oses = 'macosx-10.x-arm64'
+                    oses = 'macosx_10_9_arm64'
             elif platform == 'win32':
                 if architecture0 == '32bit':
                     oses = 'win32'

--- a/setup.py
+++ b/setup.py
@@ -5,27 +5,14 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 import sys
 
-PYTHON_INTERPRETERS = '.'.join([
-    'cp26', 'cp27',
-    'cp32', 'cp33', 'cp34', 'cp35', 'cp36',
-    'pp27',
-    'pp32', 'pp33',
-])
-MACOSX_VERSIONS = '.'.join([
-    'macosx_10_5_x86_64',
-    'macosx_10_6_intel',
-    'macosx_10_9_intel',
-    'macosx_10_9_x86_64',
-])
-
 # environment variables for cross-platform package creation
 platform = os.environ.get('PYSOUNDFILE_PLATFORM', sys.platform)
 architecture0 = os.environ.get('PYSOUNDFILE_ARCHITECTURE', architecture()[0])
 
 if platform == 'darwin':
-    libname = 'libsndfile.dylib'
+    libname = 'libsndfile_' + architecture0 + '.dylib'
 elif platform == 'win32':
-    libname = 'libsndfile' + architecture0 + '.dll'
+    libname = 'libsndfile_' + architecture0 + '.dll'
 else:
     libname = None
 
@@ -70,9 +57,12 @@ else:
         """Create OS-dependent, but Python-independent wheels."""
 
         def get_tag(self):
-            pythons = 'py2.py3.' + PYTHON_INTERPRETERS
+            pythons = 'py2.py3'
             if platform == 'darwin':
-                oses = MACOSX_VERSIONS
+                if architecture0 == 'x86_64':
+                    oses = 'macosx-10.x-x86_64'
+                else:
+                    oses = 'macosx-10.x-arm64'
             elif platform == 'win32':
                 if architecture0 == '32bit':
                     oses = 'win32'
@@ -87,7 +77,7 @@ else:
 
 setup(
     name='soundfile',
-    version='0.10.3post1',
+    version='0.11.0b1',
     description='An audio library based on libsndfile, CFFI and NumPy',
     author='Bastian Bechtold',
     author_email='basti@bastibe.de',

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ else:
                 if architecture0 == 'x86_64':
                     oses = 'macosx_10_9_x86_64.macosx_11_0_x86_64'
                 else:
-                    oses = 'macosx_11_0_arm64'
+                    oses = 'macosx_10_9_arm64.macosx_11_0_arm64'
             elif platform == 'win32':
                 if architecture0 == '32bit':
                     oses = 'win32'

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ else:
 
 setup(
     name='soundfile',
-    version='0.11.0b1',
+    version='0.11.0',
     description='An audio library based on libsndfile, CFFI and NumPy',
     author='Bastian Bechtold',
     author_email='basti@bastibe.de',

--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,9 @@ else:
             pythons = 'py2.py3'
             if platform == 'darwin':
                 if architecture0 == 'x86_64':
-                    oses = 'macosx_10_9_x86_64'
+                    oses = 'macosx_10_9_x86_64.macosx_11_0_x86_64'
                 else:
-                    oses = 'macosx_10_9_arm64'
+                    oses = 'macosx_11_0_arm64'
             elif platform == 'win32':
                 if architecture0 == '32bit':
                     oses = 'win32'

--- a/soundfile.py
+++ b/soundfile.py
@@ -61,36 +61,44 @@ _formats = {
     'OGG':   0x200000,  # Xiph OGG container
     'MPC2K': 0x210000,  # Akai MPC 2000 sampler
     'RF64':  0x220000,  # RF64 WAV file
+    'MPEG':  0x230000,  # MPEG-1/2 audio stream
 }
 
 _subtypes = {
-    'PCM_S8':    0x0001,  # Signed 8 bit data
-    'PCM_16':    0x0002,  # Signed 16 bit data
-    'PCM_24':    0x0003,  # Signed 24 bit data
-    'PCM_32':    0x0004,  # Signed 32 bit data
-    'PCM_U8':    0x0005,  # Unsigned 8 bit data (WAV and RAW only)
-    'FLOAT':     0x0006,  # 32 bit float data
-    'DOUBLE':    0x0007,  # 64 bit float data
-    'ULAW':      0x0010,  # U-Law encoded.
-    'ALAW':      0x0011,  # A-Law encoded.
-    'IMA_ADPCM': 0x0012,  # IMA ADPCM.
-    'MS_ADPCM':  0x0013,  # Microsoft ADPCM.
-    'GSM610':    0x0020,  # GSM 6.10 encoding.
-    'VOX_ADPCM': 0x0021,  # OKI / Dialogix ADPCM
-    'G721_32':   0x0030,  # 32kbs G721 ADPCM encoding.
-    'G723_24':   0x0031,  # 24kbs G723 ADPCM encoding.
-    'G723_40':   0x0032,  # 40kbs G723 ADPCM encoding.
-    'DWVW_12':   0x0040,  # 12 bit Delta Width Variable Word encoding.
-    'DWVW_16':   0x0041,  # 16 bit Delta Width Variable Word encoding.
-    'DWVW_24':   0x0042,  # 24 bit Delta Width Variable Word encoding.
-    'DWVW_N':    0x0043,  # N bit Delta Width Variable Word encoding.
-    'DPCM_8':    0x0050,  # 8 bit differential PCM (XI only)
-    'DPCM_16':   0x0051,  # 16 bit differential PCM (XI only)
-    'VORBIS':    0x0060,  # Xiph Vorbis encoding.
-    'ALAC_16':   0x0070,  # Apple Lossless Audio Codec (16 bit).
-    'ALAC_20':   0x0071,  # Apple Lossless Audio Codec (20 bit).
-    'ALAC_24':   0x0072,  # Apple Lossless Audio Codec (24 bit).
-    'ALAC_32':   0x0073,  # Apple Lossless Audio Codec (32 bit).
+    'PCM_S8':         0x0001,  # Signed 8 bit data
+    'PCM_16':         0x0002,  # Signed 16 bit data
+    'PCM_24':         0x0003,  # Signed 24 bit data
+    'PCM_32':         0x0004,  # Signed 32 bit data
+    'PCM_U8':         0x0005,  # Unsigned 8 bit data (WAV and RAW only)
+    'FLOAT':          0x0006,  # 32 bit float data
+    'DOUBLE':         0x0007,  # 64 bit float data
+    'ULAW':           0x0010,  # U-Law encoded.
+    'ALAW':           0x0011,  # A-Law encoded.
+    'IMA_ADPCM':      0x0012,  # IMA ADPCM.
+    'MS_ADPCM':       0x0013,  # Microsoft ADPCM.
+    'GSM610':         0x0020,  # GSM 6.10 encoding.
+    'VOX_ADPCM':      0x0021,  # OKI / Dialogix ADPCM
+    'NMS_ADPCM_16':   0x0022,  # 16kbs NMS G721-variant encoding.
+    'NMS_ADPCM_24':   0x0023,  # 24kbs NMS G721-variant encoding.
+    'NMS_ADPCM_32':   0x0024,  # 32kbs NMS G721-variant encoding.
+    'G721_32':        0x0030,  # 32kbs G721 ADPCM encoding.
+    'G723_24':        0x0031,  # 24kbs G723 ADPCM encoding.
+    'G723_40':        0x0032,  # 40kbs G723 ADPCM encoding.
+    'DWVW_12':        0x0040,  # 12 bit Delta Width Variable Word encoding.
+    'DWVW_16':        0x0041,  # 16 bit Delta Width Variable Word encoding.
+    'DWVW_24':        0x0042,  # 24 bit Delta Width Variable Word encoding.
+    'DWVW_N':         0x0043,  # N bit Delta Width Variable Word encoding.
+    'DPCM_8':         0x0050,  # 8 bit differential PCM (XI only)
+    'DPCM_16':        0x0051,  # 16 bit differential PCM (XI only)
+    'VORBIS':         0x0060,  # Xiph Vorbis encoding.
+    'OPUS':           0x0064,  # Xiph/Skype Opus encoding.
+    'ALAC_16':        0x0070,  # Apple Lossless Audio Codec (16 bit).
+    'ALAC_20':        0x0071,  # Apple Lossless Audio Codec (20 bit).
+    'ALAC_24':        0x0072,  # Apple Lossless Audio Codec (24 bit).
+    'ALAC_32':        0x0073,  # Apple Lossless Audio Codec (32 bit).
+    'MPEG_LAYER_I':   0x0080,  # MPEG-1 Audio Layer I.
+    'MPEG_LAYER_II':  0x0081,  # MPEG-1 Audio Layer II.
+    'MPEG_LAYER_III': 0x0082,  # MPEG-2 Audio Layer III.
 }
 
 _endians = {
@@ -127,6 +135,7 @@ _default_subtypes = {
     'OGG':   'VORBIS',
     'MPC2K': 'PCM_16',
     'RF64':  'PCM_16',
+    'MPEG':  'MPEG_LAYER_III',
 }
 
 _ffi_types = {

--- a/soundfile.py
+++ b/soundfile.py
@@ -61,7 +61,7 @@ _formats = {
     'OGG':   0x200000,  # Xiph OGG container
     'MPC2K': 0x210000,  # Akai MPC 2000 sampler
     'RF64':  0x220000,  # RF64 WAV file
-    'MPEG':  0x230000,  # MPEG-1/2 audio stream
+    'MP3':   0x230000,  # MPEG-1/2 audio stream
 }
 
 _subtypes = {
@@ -135,7 +135,7 @@ _default_subtypes = {
     'OGG':   'VORBIS',
     'MPC2K': 'PCM_16',
     'RF64':  'PCM_16',
-    'MPEG':  'MPEG_LAYER_III',
+    'MP3':   'MPEG_LAYER_III',
 }
 
 _ffi_types = {

--- a/tests/test_soundfile.py
+++ b/tests/test_soundfile.py
@@ -101,31 +101,31 @@ def file_wplus(request):
     return _file_new(request, os.O_CREAT | os.O_RDWR, 'w+b')
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def file_inmemory():
     with io.BytesIO() as f:
         yield f
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def sf_stereo_r(file_stereo_r):
     with sf.SoundFile(file_stereo_r) as f:
         yield f
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def sf_stereo_w(file_w):
     with sf.SoundFile(file_w, 'w', 44100, 2, format='WAV') as f:
         yield f
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def sf_stereo_rplus(file_stereo_rplus):
     with sf.SoundFile(file_stereo_rplus, 'r+') as f:
         yield f
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def sf_stereo_wplus(file_wplus):
     with sf.SoundFile(file_wplus, 'w+', 44100, 2,
                       format='WAV', subtype='FLOAT') as f:

--- a/tests/test_soundfile.py
+++ b/tests/test_soundfile.py
@@ -592,7 +592,8 @@ def test_file_content(sf_stereo_r):
 
 def test_file_attributes_in_read_mode(sf_stereo_r):
     if isinstance(sf_stereo_r.name, str):
-        assert sf_stereo_r.name == filename_stereo
+        # wrap in pathlib, to make tests pass on Windows:
+        assert pathlib.Path(sf_stereo_r.name) == pathlib.Path(filename_stereo)
     elif not isinstance(sf_stereo_r.name, int):
         assert sf_stereo_r.name.name == filename_stereo
     assert sf_stereo_r.mode == 'r'


### PR DESCRIPTION
A new release for soundfile.

Thank you, tennies, Hannes Helmholz, Christoph Boeddeker, Matt
Vollrath, Matthias Geier, Jacek Konieczny, Boris Verkhovskiy,
Jonas Haag, Eduardo Moguillansky, Panos Laganakos, Jarvy Jarvison,
Domingo Ramirez, Tim Chagnon, Kyle Benesch

- Adds binary wheels for macOS M1
- Improves compatibility with macOS, specifically for M1 machines
- Fixes file descriptor open for binary wheels on Windows and Python 3.5+
- Updates libsndfile to v1.0.31
- Adds get_strings method for retrieving all metadata at once
- Improves documentation, error messages and tests
- Displays length of very short files in samples
- Supports the file system path protocol (pathlib et al)
