### PR TITLE
Add Python testing workflow.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,45 @@
+name: Python Package
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        python-version:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "pypy-3.7"
+          - "pypy-3.8"
+        architecture: ["x86", "x64"]
+        exclude:
+          - os: macos-10.15 # Can't compile Numpy for this implementation.
+            python-version: "pypy-3.7"
+          - os: macos-10.15
+            architecture: "x86"
+          - os: ubuntu-20.04
+            architecture: "x86"
+
+    steps:
+      - name: Install APT dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libsndfile1
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+      - name: Install requirements
+        run: pip install numpy pytest
+      - name: Install editable package
+        run: pip install --editable . --verbose
+      - name: Run tests
+        run: python -m pytest


### PR DESCRIPTION
I've excluded Python 2.7 and 3.5 for my own sanity.  You can try to enable them later but I do not recommend it.  I've also excluded PyPy 3.7 on MacOS since Numpy compiles incorrectly for that version.

All Windows tests currently fail.  This is likely because the DLL's are not yet updated on master.  This PR can still be merged and used test the new Windows DLL's.