### PR TITLE
Fix NameError for _machine reference when loading 'sndfile' library on darwin

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -144,7 +144,7 @@ try:
 except OSError:
     if _sys.platform == 'darwin':
         from platform import machine as _machine
-        _packaged_libname = 'libsndfile_' + machine() + '.dylib'
+        _packaged_libname = 'libsndfile_' + _machine() + '.dylib'
         _libname = 'libsndfile.dylib'
     elif _sys.platform == 'win32':
         from platform import architecture as _architecture


### PR DESCRIPTION
There has been a typo with `machine` variable resulting `NameError: name 'machine' is not defined` which is fixed here.