### PR TITLE
ABI mode to API mode transition on cffi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ In 0.9.0, we changed the ``ctype`` arguments of the ``buffer_*``
 methods to ``dtype``, using the Numpy ``dtype`` notation. The old
 ``ctype`` arguments still work, but are now officially deprecated.
 
+In 0.11.0 switched from cffi ABI mode to API mode
 Installation
 ------------
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ else:
 
 setup(
     name='soundfile',
-    version='0.10.3post1',
+    version='0.11.1',
     description='An audio library based on libsndfile, CFFI and NumPy',
     author='Bastian Bechtold',
     author_email='basti@bastibe.de',

--- a/soundfile_build.py
+++ b/soundfile_build.py
@@ -1,9 +1,15 @@
 import os
 import sys
 from cffi import FFI
+platform = os.environ.get('PYSOUNDFILE_PLATFORM', sys.platform)
+print(platform)
 
 ffibuilder = FFI()
-ffibuilder.set_source("_soundfile", None)
+
+ffibuilder.set_source('_soundfile', '''
+#include <sndfile.h>
+''', libraries=['sndfile'])
+
 ffibuilder.cdef("""
 enum
 {
@@ -44,6 +50,8 @@ typedef int64_t sf_count_t ;
 
 typedef struct SNDFILE_tag SNDFILE ;
 
+
+
 typedef struct SF_INFO
 {
     sf_count_t frames ;        /* Used to be called samples.  Changed to avoid confusion. */
@@ -52,8 +60,15 @@ typedef struct SF_INFO
     int        format ;
     int        sections ;
     int        seekable ;
-} SF_INFO ;
+} SF_INFO ;""")
 
+if platform == 'win32':
+    ffibuilder.cdef("""
+    SNDFILE* sf_wchar_open (const wchar_t *wpath, int mode, SF_INFO *sfinfo);
+    """)
+
+ffibuilder.cdef(
+"""
 SNDFILE*    sf_open          (const char *path, int mode, SF_INFO *sfinfo) ;
 int         sf_format_check  (const SF_INFO *info) ;
 
@@ -108,6 +123,7 @@ typedef sf_count_t  (*sf_vio_read)        (void *ptr, sf_count_t count, void *us
 typedef sf_count_t  (*sf_vio_write)       (const void *ptr, sf_count_t count, void *user_data) ;
 typedef sf_count_t  (*sf_vio_tell)        (void *user_data) ;
 
+
 typedef struct SF_VIRTUAL_IO
 {    sf_count_t  (*get_filelen) (void *user_data) ;
      sf_count_t  (*seek)        (sf_count_t offset, int whence, void *user_data) ;
@@ -115,6 +131,7 @@ typedef struct SF_VIRTUAL_IO
      sf_count_t  (*write)       (const void *ptr, sf_count_t count, void *user_data) ;
      sf_count_t  (*tell)        (void *user_data) ;
 } SF_VIRTUAL_IO ;
+
 
 SNDFILE*    sf_open_virtual   (SF_VIRTUAL_IO *sfvirtual, int mode, SF_INFO *sfinfo, void *user_data) ;
 SNDFILE*    sf_open_fd        (int fd, int mode, SF_INFO *sfinfo, int close_desc) ;
@@ -125,13 +142,14 @@ typedef struct SF_FORMAT_INFO
     const char* name ;
     const char* extension ;
 } SF_FORMAT_INFO ;
-""")
 
-platform = os.environ.get('PYSOUNDFILE_PLATFORM', sys.platform)
-if platform == 'win32':
-    ffibuilder.cdef("""
-    SNDFILE* sf_wchar_open (const wchar_t *wpath, int mode, SF_INFO *sfinfo) ;
-    """)
+extern "Python" sf_count_t  vio_get_filelen (void *user_data) ;
+extern "Python" sf_count_t  vio_seek        (sf_count_t offset, int whence, void *user_data) ;
+extern "Python" sf_count_t  vio_read        (void *ptr, sf_count_t count, void *user_data) ;
+extern "Python" sf_count_t  vio_write       (const void *ptr, sf_count_t count, void *user_data) ;
+extern "Python" sf_count_t  vio_tell        (void *user_data) ;
+
+""")
 
 if __name__ == "__main__":
     ffibuilder.compile(verbose=True)


### PR DESCRIPTION
Build error on win32 due to the declaration:
"""
    SNDFILE* sf_wchar_open (const wchar_t *wpath, int mode, SF_INFO *sfinfo);
    """
Perhaps it should be removed.

Tested on Macbook Pro M1 and works with no issues.