### PR TITLE
More robust check for _soundfile_data package

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -168,7 +168,7 @@ except OSError:
     # try packaged lib (in _soundfile_data which should be on python path)
     try:  # packaged libsndfile:
         import _soundfile_data  # ImportError if this doesn't exist
-        _path = _os.path.dirname(_soundfile_data.__path__[0])
+        _path = _os.path.dirname(_soundfile_data.__file__)
         _full_path = _os.path.join(_path, _packaged_libname)
         _snd = _ffi.dlopen(_full_path)
     except (OSError, ImportError):  # try system-wide libsndfile:

--- a/soundfile.py
+++ b/soundfile.py
@@ -168,8 +168,9 @@ except OSError:
     # try packaged lib (in _soundfile_data which should be on python path)
     try:  # packaged libsndfile:
         import _soundfile_data  # ImportError if this doesn't exist
-        _path = _os.path.dirname(_soundfile_data.__path__)
-        _snd = _ffi.dlopen(_os.path.join(_path, _packaged_libname))
+        _path = _os.path.dirname(_soundfile_data.__path__[0])
+        _full_path = _os.path.join(_path, _packaged_libname)
+        _snd = _ffi.dlopen(_full_path)
     except (OSError, ImportError):  # try system-wide libsndfile:
         # Homebrew on Apple M1 uses a `/opt/homebrew/lib` instead of
         # `/usr/local/lib`. We are making sure we pick that up.


### PR DESCRIPTION
Rather than trying to create the location for `_soundfile_data/` manually, simply import it and use its reported `__path__`

The existing method fails if using macos lib packaged with py2app because:

- starting path for soundfile is `/lib/python38.zip/soundfile.py`
- desired path fro soundfile_data  is `/lib/python3.8/_soundfile_data`
- the previous method of stepping back from the starting path never reaches this desired path (it tries `/lib/_soundfile_data` and fails)