### PR TITLE
Please test the beta release: V0.12.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,10 +59,11 @@ The ``soundfile`` module depends on the Python packages CFFI and NumPy, and the
 system library libsndfile.
 
 In a modern Python, you can use ``pip install soundfile`` to download
-and install the latest release of the ``soundfile`` module and its dependencies.
-On Windows and OS X, this will also install the library libsndfile.
-On Linux, you need to install libsndfile using your distribution's
-package manager, for example ``sudo apt-get install libsndfile1``.
+and install the latest release of the ``soundfile`` module and its
+dependencies. On Windows and OS X and Linux 64, this will also install
+the library libsndfile. On Linux, you need to install libsndfile using
+your distribution's package manager, for example ``sudo apt-get
+install libsndfile1``.
 
 If you are running on an unusual platform or if you are using an older
 version of Python, you might need to install NumPy and CFFI separately,
@@ -309,3 +310,11 @@ News
     - Improves documentation, error messages and tests
     - Displays length of very short files in samples
     - Supports the file system path protocol (pathlib et al)
+
+2023-02-02 V0.12.0 Bastian Bechtold
+    Thank you, Barabazs, Andrew Murray, Jon Peirce, for contributions
+    to this release.
+
+    - Updated libsndfile to v1.2.0
+    - Improves precompiled library location, especially with py2app or cx-freeze.
+    - Now provide binary wheels for Linux x86_64

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ interface for Python calling C code. CFFI is supported for CPython 2.6+,
 Breaking Changes
 ----------------
 
-The ``soundfile`` module has evolved rapidly during the last few releases. Most
+The ``soundfile`` module has evolved rapidly in the past. Most
 notably, we changed the import name from ``import pysoundfile`` to
 ``import soundfile`` in 0.7. In 0.6, we cleaned up many small
 inconsistencies, particularly in the the ordering and naming of
@@ -60,10 +60,11 @@ system library libsndfile.
 
 In a modern Python, you can use ``pip install soundfile`` to download
 and install the latest release of the ``soundfile`` module and its
-dependencies. On Windows and OS X and Linux 64, this will also install
-the library libsndfile. On Linux, you need to install libsndfile using
-your distribution's package manager, for example ``sudo apt-get
-install libsndfile1``.
+dependencies. On Windows (64/32) and OS X (Intel/ARM) and Linux 64,
+this will also install a current version of the library libsndfile. If
+you install the source module, you need to install libsndfile using
+your distribution's package manager, for example ``sudo apt install
+libsndfile1``.
 
 If you are running on an unusual platform or if you are using an older
 version of Python, you might need to install NumPy and CFFI separately,

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Installation
 ------------
 
 The ``soundfile`` module depends on the Python packages CFFI and NumPy, and the
-system library libsndfile.
+library libsndfile.
 
 In a modern Python, you can use ``pip install soundfile`` to download
 and install the latest release of the ``soundfile`` module and its
@@ -78,6 +78,24 @@ for example using the Anaconda_ package manager or the `Unofficial Windows
 Binaries for Python Extension Packages <http://www.lfd.uci.edu/~gohlke/pythonlibs/>`_.
 
 .. _Anaconda: https://www.continuum.io/downloads
+
+Building
+--------
+
+``Soundfile`` itself does not contain any compiled code and can be
+bundled into a wheel with the usual ``python setup.py bdist_wheel``.
+However, ``soundfile`` relies on libsndfile, and optionally ships its
+own copy of libsndfile in the wheel.
+
+To build a binary wheel that contains libsndfile, make sure to
+checkout and update the ``_soundfile_data`` submodule, then run
+``python setup.py bdist_wheel`` as usual. If the resulting file size
+of the wheel is around one megabyte, a matching libsndfile has been
+bundled (without libsndfile, it's around 25 KB).
+
+To build binary wheels for all supported platforms, run ``python
+build_wheels.py``, which will ``python setup.py bdist_wheel`` for each
+of the platforms we have precompiled libsndfiles for.
 
 Error Reporting
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,12 @@ In 0.9.0, we changed the ``ctype`` arguments of the ``buffer_*``
 methods to ``dtype``, using the Numpy ``dtype`` notation. The old
 ``ctype`` arguments still work, but are now officially deprecated.
 
+In 0.12.0, we changed the load order of the libsndfile library. Now,
+the packaged libsndfile in the platform-specific wheels is tried
+before falling back to any system-provided libsndfile. If you would
+prefer using the system-provided libsndfile, install the source
+package or source wheel instead of the platform-specific wheels.
+
 Installation
 ------------
 
@@ -319,3 +325,4 @@ News
     - Updated libsndfile to v1.2.0
     - Improves precompiled library location, especially with py2app or cx-freeze.
     - Now provide binary wheels for Linux x86_64
+    - Now prefers packaged libsndfile over system-installed libsndfile

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -3,6 +3,7 @@ import shutil
 
 architectures = dict(darwin=['x86_64', 'arm64'],
                      win32=['32bit', '64bit'],
+                     linux=['x86_64'],
                      noplatform='noarch')
 
 def cleanup():

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ if platform == 'darwin':
     libname = 'libsndfile_' + architecture0 + '.dylib'
 elif platform == 'win32':
     libname = 'libsndfile_' + architecture0 + '.dll'
+elif platform == 'linux':
+    libname = 'libsndfile_' + architecture0 + '.so'
 else:
     libname = None
 
@@ -60,14 +62,18 @@ else:
             pythons = 'py2.py3'
             if platform == 'darwin':
                 if architecture0 == 'x86_64':
-                    oses = 'macosx_10_9_x86_64.macosx_11_0_x86_64'
+                    oses = 'macosx_10_9_x86_64'
                 else:
-                    oses = 'macosx_10_9_arm64.macosx_11_0_arm64'
+                    oses = 'macosx_11_0_arm64'
             elif platform == 'win32':
                 if architecture0 == '32bit':
                     oses = 'win32'
                 else:
                     oses = 'win_amd64'
+            elif platform == 'linux':
+                # the oldest mainline github runner available is ubuntu 20.04,
+                # which runs glibc 2.31:
+                oses = 'manylinux_2_31_x86_64'
             else:
                 pythons = 'py2.py3'
                 oses = 'any'
@@ -77,7 +83,7 @@ else:
 
 setup(
     name='soundfile',
-    version='0.11.0',
+    version='0.12.0',
     description='An audio library based on libsndfile, CFFI and NumPy',
     author='Bastian Bechtold',
     author_email='basti@bastibe.de',

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python
 import os
-from platform import architecture
+from platform import architecture, machine
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 import sys
 
 # environment variables for cross-platform package creation
 platform = os.environ.get('PYSOUNDFILE_PLATFORM', sys.platform)
-architecture0 = os.environ.get('PYSOUNDFILE_ARCHITECTURE', architecture()[0])
+architecture0 = os.environ.get('PYSOUNDFILE_ARCHITECTURE')
+if architecture0 is None:
+    # follow the same decision tree as in soundfile.py after
+    # _find_library('sndfile') fails:
+    if sys.platform == 'win32':
+        architecture0 = architecture()[0]  # 64bit or 32bit
+    else:
+        architecture0 = machine()  # x86_64 or arm64
 
 if platform == 'darwin':
     libname = 'libsndfile_' + architecture0 + '.dylib'

--- a/setup.py
+++ b/setup.py
@@ -81,9 +81,18 @@ else:
 
     cmdclass['bdist_wheel'] = bdist_wheel_half_pure
 
+with open('soundfile.py') as f:
+    for line in f:
+        if line.startswith('__version__'):
+            _, soundfile_version = line.split('=')
+            soundfile_version = soundfile_version.strip(' "\'\n')
+            break
+    else:
+         raise RuntimeError("Could not find __version__ in soundfile.py")
+
 setup(
     name='soundfile',
-    version='0.12.0',
+    version=soundfile_version,
     description='An audio library based on libsndfile, CFFI and NumPy',
     author='Bastian Bechtold',
     author_email='basti@bastibe.de',

--- a/soundfile.py
+++ b/soundfile.py
@@ -159,11 +159,11 @@ try:  # packaged lib (in _soundfile_data which should be on python path)
         raise OSError('no packaged library for this platform')
 
     import _soundfile_data  # ImportError if this doesn't exist
-    _path = _os.path.dirname(_soundfile_data.__file__)
+    _path = _os.path.dirname(_soundfile_data.__file__)  # TypeError if __file__ is None
     _full_path = _os.path.join(_path, _packaged_libname)
     _snd = _ffi.dlopen(_full_path)  # OSError if file doesn't exist or can't be loaded
 
-except (OSError, ImportError):
+except (OSError, ImportError, TypeError):
     try:  # system-wide libsndfile:
         _libname = _find_library('sndfile')
         if _libname is None:

--- a/soundfile.py
+++ b/soundfile.py
@@ -148,7 +148,7 @@ _ffi_types = {
 try:
     _libname = _find_library('sndfile')
     if _libname is None:
-        raise OSError('sndfile library not found')
+        raise OSError('sndfile library not found using ctypes.util.find_library')
     _snd = _ffi.dlopen(_libname)
 except OSError:
     if _sys.platform == 'darwin':
@@ -160,23 +160,19 @@ except OSError:
         _packaged_libname = 'libsndfile_' + _architecture()[0] + '.dll'
         _libname = 'libsndfile.dll'
     elif _sys.platform == 'linux':
-        _packaged_libname = 'libsndfile.so'  # not provided!
+        from platform import machine as _machine
+        _packaged_libname = 'libsndfile_' + _machine() + '.so'
         _libname = 'libsndfile.so'
     else:
         raise
 
-    # hack for packaging tools like cx_Freeze, which
-    # compress all scripts into a zip file
-    # which causes __file__ to be inside this zip file
-
-    _path = _os.path.dirname(_os.path.abspath(__file__))
-
-    while not _os.path.isdir(_path):
-        _path = _os.path.abspath(_os.path.join(_path, '..'))
-
+    # try packaged lib (in _soundfile_data which should be on python path)
     try:  # packaged libsndfile:
-        _snd = _ffi.dlopen(_os.path.join(_path, '_soundfile_data', _packaged_libname))
-    except OSError:  # try system-wide libsndfile:
+        import _soundfile_data  # ImportError if this doesn't exist
+        _path = _os.path.dirname(_soundfile_data.__file__)
+        _full_path = _os.path.join(_path, _packaged_libname)
+        _snd = _ffi.dlopen(_full_path)
+    except (OSError, ImportError):  # try system-wide libsndfile:
         # Homebrew on Apple M1 uses a `/opt/homebrew/lib` instead of
         # `/usr/local/lib`. We are making sure we pick that up.
         from platform import machine as _machine

--- a/soundfile.py
+++ b/soundfile.py
@@ -8,7 +8,7 @@ Alternatively, sound files can be opened as `SoundFile` objects.
 For further information, see https://python-soundfile.readthedocs.io/.
 
 """
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 import os as _os
 import sys as _sys


### PR DESCRIPTION
Dear soundfile community,

Find attached a beta release of the next version of soundfile, with

- libsndfile v1.2.0
- manylinux binary wheel
- improved libsndfile discovery

I would be grateful if you could test the wheels on the platform of your choice, and report back if they work, or if there are any issues.

[soundfile-0.12.0.wheels.zip](https://github.com/bastibe/python-soundfile/files/10695743/soundfile-0.12.0.wheels.zip)