### PR TITLE
Fix arch detection on darwin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import os
-from platform import architecture
+from platform import architecture, machine
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 import sys
@@ -59,7 +59,7 @@ else:
         def get_tag(self):
             pythons = 'py2.py3'
             if platform == 'darwin':
-                if architecture0 == 'x86_64':
+                if machine() == 'x86_64':
                     oses = 'macosx_10_9_x86_64.macosx_11_0_x86_64'
                 else:
                     oses = 'macosx_10_9_arm64.macosx_11_0_arm64'


### PR DESCRIPTION
macOS Intel:

    >>> platform.architecture()[0]
    '64bit'
    >>> platform.machine()
    'x86_64'

macOS M1:

    >>> platform.architecture()[0]
    '64bit'
    >>> platform.machine()
    'arm64'