### PR TITLE
Add linux arm64 to build_wheels.py

### DIFF
--- a/build_wheels.py
+++ b/build_wheels.py
@@ -3,7 +3,7 @@ import shutil
 
 architectures = dict(darwin=['x86_64', 'arm64'],
                      win32=['32bit', '64bit'],
-                     linux=['x86_64'],
+                     linux=['x86_64', 'arm64'],
                      noplatform='noarch')
 
 def cleanup():


### PR DESCRIPTION
#381

I found it would be very straightforward to add `arm64` support for linux because we already have prebuilt binary for it.