### PR TITLE
Update soundfile.py

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -148,7 +148,7 @@ _ffi_types = {
 try:  # packaged lib (in _soundfile_data which should be on python path)
     if _sys.platform == 'darwin':
         from platform import machine as _machine
-        _packaged_libname = 'libsndfile_' + _machine() + '.dylib'
+        _packaged_libname = 'libsndfile.dylib'
     elif _sys.platform == 'win32':
         from platform import architecture as _architecture
         _packaged_libname = 'libsndfile_' + _architecture()[0] + '.dll'


### PR DESCRIPTION
on mac this error occur when try to run: 
/usr/lib/libsndfile.dylib' (no such file)
this error occurs because of the naming of the file on the code.
Current file name is libsndfile_arm.dylib but program call it libsndfile.dylib
 when I delete the '_arm' from file name problem is fixed. most likely there is a problem calling the file