### PR TITLE
Require numpy for all installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,9 +111,9 @@ setup(
     zip_safe=zip_safe,
     license='BSD 3-Clause License',
     setup_requires=["cffi>=1.0"],
-    install_requires=['cffi>=1.0'],
+    install_requires=['cffi>=1.0', 'numpy'],
     cffi_modules=["soundfile_build.py:ffibuilder"],
-    extras_require={'numpy': ['numpy']},
+    extras_require={'numpy': []},
     platforms='any',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
     setup_requires=["cffi>=1.0"],
     install_requires=['cffi>=1.0', 'numpy'],
     cffi_modules=["soundfile_build.py:ffibuilder"],
-    extras_require={'numpy': []},
+    extras_require={'numpy': []}, # This option is no longer relevant, but the empty entry must be left in to avoid breaking old build scripts.
     platforms='any',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
See discussion in #408. This may not be how you prefer to solve this.

It would be better if numpy were requested with a >= version number but I don't know which one is appropriate.