### PR TITLE
updates README: in-memory virtual IO example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,6 +220,27 @@ For Python 2.x support, replace the third line with:
 
     from urllib2 import urlopen
 
+In-memory files
+^^^^^^^^^^^^^^^
+
+Chunks of audio, i.e. `bytes`, can also be read and written without touching the filesystem.
+In the following example OGG is converted to WAV entirely in memory (without writing files to the disk):
+
+.. code:: python
+
+    import io
+    import soundfile as sf
+
+    def ogg2wav(ogg: bytes):
+        ogg_buf = io.BytesIO(ogg)
+        ogg_buf.name = 'file.ogg'
+        data, samplerate = sf.read(ogg_buf)
+        wav_buf = io.BytesIO()
+        wav_buf.name = 'file.wav'
+        sf.write(wav_buf, data, samplerate)
+        wav_buf.seek(0)  # Necessary for `.read()` to return all bytes
+        return wav_buf.read()
+
 Known Issues
 ------------
 


### PR DESCRIPTION
Fixes #333 

---

**Note**

I couldn't check the compiled HTML because I got the following error:

```
python setup.py build_sphinx
python-soundfile/venv/lib/python3.11/site-packages/setuptools/__init__.py:80: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

!!
  dist.fetch_build_eggs(dist.setup_requires)
WARNING: The wheel package is not available.
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'build_sphinx'
```

If this is not just a problem with my local setup, `CONTRIBUTING.rst` might need to be adjusted, as well.