### PR TITLE
Add Linux ARM64 (aarch64) wheel support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,12 @@ else:
                     oses = 'win_amd64'
             elif platform == 'linux':
                 # using the centos:7 runner with glibc2.17:
-                oses = 'manylinux_2_17_{}'.format(architecture0)
+                if architecture0 == 'arm64':
+                    pep600_architecture = 'aarch64'
+                else:
+                    pep600_architecture = architecture0
+
+                oses = 'manylinux_2_17_{}'.format(pep600_architecture)
             else:
                 pythons = 'py2.py3'
                 oses = 'any'

--- a/soundfile.py
+++ b/soundfile.py
@@ -154,7 +154,10 @@ try:  # packaged lib (in _soundfile_data which should be on python path)
         _packaged_libname = 'libsndfile_' + _architecture()[0] + '.dll'
     elif _sys.platform == 'linux':
         from platform import machine as _machine
-        _packaged_libname = 'libsndfile_' + _machine() + '.so'
+        if _machine() in ["aarch64", "aarch64_be", "armv8b", "armv8l"]:
+            _packaged_libname = 'libsndfile_arm64.so'
+        else:
+            _packaged_libname = 'libsndfile_' + _machine() + '.so'
     else:
         raise OSError('no packaged library for this platform')
 


### PR DESCRIPTION
This pull request is taking over #382. Thanks @imWildCat ( https://github.com/bastibe/python-soundfile/pull/382#issuecomment-1774979298 )!

Add Linux ARM64 (aarch64) wheel to `build_wheels.py` and fix some platform dependent code.

Here is the main points of fixes.

- Python wheel platform tag need to be `aarch64` ([PEP 600](https://peps.python.org/pep-0600/))（the 3rd return value of `bdist_wheel.get_tag()`, [setup.py#L82](https://github.com/bastibe/python-soundfile/blob/3040e6eb07119061238c49e8d455e4196f415465/setup.py#L82)）
- Keep the `.so` filename in [bastibe/libsndfile-binaries](https://github.com/bastibe/libsndfile-binaries) as `arm64` (`PYSOUNDFILE_ARCHITECTURE`, [setup.py#L24](https://github.com/bastibe/python-soundfile/blob/3040e6eb07119061238c49e8d455e4196f415465/setup.py#L24)).
- The possible arm64 compatible architecture list `["aarch64", "aarch64_be", "armv8b", "armv8l"]` is referred to [this StackOverflow answer](https://stackoverflow.com/a/45125525) (`platform.machine()` returns `uname -m` value on Linux).

With only this pull request, pytest is not passed due to an issue of `libsndfile_arm64.so` distributed in [bastibe/libsndfile-binaries](https://github.com/bastibe/libsndfile-binaries). Please see the GitHub Issue below.

- https://github.com/bastibe/libsndfile-binaries/issues/29

Currently, this pull request does not update the submodule `_soundfile_data` to keep the reference for bastibe's repository.
Updating submodule after https://github.com/bastibe/libsndfile-binaries/issues/29 fixed is required for working properly either before or after merging this pull request.

Here is an experimental ARM64 (aarch64) binary wheel build using my own `libsndfile_arm64.so` binary ( https://github.com/bastibe/libsndfile-binaries/issues/29 fixed one). This binary successfully passes `pytest`.

- https://github.com/aoirint/python-soundfile/releases/tag/0.12.2.dev2%2Baoirint.addlinuxarm64
  - Download `soundfile-0.12.2.dev2+aoirint.addlinuxarm64-py2.py3-none-manylinux_2_17_aarch64.whl`


<details>
<summary>Full log of pytest using the experimental wheel (successfully passed)</summary>

```shell
$ python -m pytest
================================================= test session starts ==================================================
platform linux -- Python 3.11.6, pytest-7.4.2, pluggy-1.3.0
rootdir: /code
collected 324 items

tests/test_argspec.py ....                                                                                       [  1%]
tests/test_soundfile.py ........................................................................................ [ 28%]
................................................................................................................ [ 62%]
................................................................................................................ [ 97%]
........                                                                                                         [100%]

=================================================== warnings summary ===================================================
tests/test_soundfile.py::test_file_truthiness[obj]
  /home/user/.local/lib/python3.11/site-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning: Exception ignored from cffi callback <function SoundFile._init_virtual_io.<locals>.vio_write at 0x5518f63ec0>: None

  Traceback (most recent call last):
    File "/home/user/.local/lib/python3.11/site-packages/_pytest/fixtures.py", line 596, in _get_active_fixturedef
      return self._fixture_defs[argname]
             ~~~~~~~~~~~~~~~~~~^^^^^^^^^
  KeyError: 'request'

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/home/user/.local/lib/python3.11/site-packages/_pytest/fixtures.py", line 599, in _get_active_fixturedef
      fixturedef = self._getnextfixturedef(argname)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/user/.local/lib/python3.11/site-packages/_pytest/fixtures.py", line 473, in _getnextfixturedef
      raise FixtureLookupError(argname, self)
  _pytest.fixtures.FixtureLookupError: ('request', <SubRequest 'file_w' for <Function test_file_truthiness[obj]>>)

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/code/soundfile.py", line 1261, in vio_write
      written = file.write(data)
                ^^^^^^^^^^^^^^^^
  ValueError: I/O operation on closed file

    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 324 passed, 1 warning in 3.49s ============================================
```

</details>


If you are using Docker, you may test my ARM64 (aarch64) wheel build/fix on x86_64 machine with [QEMU CPU emulation](https://docs.docker.com/build/building/multi-platform/).

<details>
<summary>Commands</summary>

- Docker Hub: [arm64v8/python](https://hub.docker.com/r/arm64v8/python)

```shell
# On host machine
git clone https://github.com/aoirint/python-soundfile.git
cd python-soundfile
git checkout 5f2f5b37cd210005f0510f3d11cd9e4e0efa06e4
git submodule update --init

sudo docker run --rm -it --volume ".:/code" --platform "linux/arm64" arm64v8/python:3.11 bash
```

```shell
# As root user in Docker container
useradd --uid 1000 --create-home user
su -l user -s /bin/bash
```

```shell
# As general user in Docker container
cd /code

# If you want to build your own wheel
python build_wheels.py

# Please replace the wheel file name for your own wheel
pip install ./dist/soundfile-0.12.2.dev2+aoirint.addlinuxarm64-py2.py3-none-manylinux_2_17_aarch64.whl

pip install numpy pytest
python -m pytest
```

</details>
