### PR TITLE
Linux CI: Update apt package list before installing package

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,9 @@ jobs:
     steps:
       - name: Install APT dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install libsndfile1
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsndfile1
       - uses: actions/checkout@v2
         with:
           submodules: true


### PR DESCRIPTION
Recent test CI jobs on Ubuntu 20.04 were failed due to the out-dated apt package list cache of CI virtual machine.

- e.g. https://github.com/bastibe/python-soundfile/actions/runs/6613147987/job/18360406630

The package list should be updated before installing any apt package on CI.

This pull request add `apt-get update` before `apt-get install` to update apt package list.

In the future, maybe this installation command should be removed since `libsndfile.so` is already bundled in `soundfile` package on Linux x64 ( #364 ).
Or CI should be rewrited to test both the system library and the bundled library.
This pull request is intended to maintain the current CI behavior without major changes.

Failed CI log ( https://github.com/bastibe/python-soundfile/actions/runs/6613147987/job/18360406630 )

```shell
$ sudo apt-get install libsndfile1
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libflac8 libvorbisenc2
The following NEW packages will be installed:
  libflac8 libsndfile1 libvorbisenc2
0 upgraded, 3 newly installed, 0 to remove and 15 not upgraded.
Need to get 344 kB of archives.
After this operation, 1554 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libflac8 amd64 1.3.3-1ubuntu0.2 [103 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libvorbisenc2 amd64 1.3.6-2ubuntu1 [70.7 kB]
Ign:4 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libsndfile1 amd64 1.0.28-7ubuntu0.1
Ign:4 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libsndfile1 amd64 1.0.28-7ubuntu0.1
Ign:4 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libsndfile1 amd64 1.0.28-7ubuntu0.1
Err:4 mirror+file:/etc/apt/apt-mirrors.txt focal-updates/main amd64 libsndfile1 amd64 1.0.28-7ubuntu0.1
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/libs/libsndfile/libsndfile1_1.0.28-7ubuntu0.1_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
Fetched 174 kB in 1s (140 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```
