### PR TITLE
macOS CI: Update macOS runner to macOS 11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         python-version:
           - "3.6"
           - "3.7"
@@ -20,9 +20,9 @@ jobs:
           - "pypy-3.8"
         architecture: ["x86", "x64"]
         exclude:
-          - os: macos-10.15 # Can't compile Numpy for this implementation.
+          - os: macos-11 # Can't compile Numpy for this implementation.
             python-version: "pypy-3.7"
-          - os: macos-10.15
+          - os: macos-11
             architecture: "x86"
           - os: ubuntu-20.04
             architecture: "x86"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
           - "pypy-3.8"
         architecture: ["x86", "x64"]
         exclude:
-          - os: macos-11 # Can't compile Numpy for this implementation.
+          - os: macos-11 # No Numpy binary wheel
             python-version: "pypy-3.7"
           - os: macos-11
             architecture: "x86"


### PR DESCRIPTION
This pull request updates macOS version on test CI to macOS 11.

GitHub no longer provides macOS 10.15 CI runners after 2022-12-01. And macOS 10.15 Catalina seems to be End-Of-Life.

- https://github.com/actions/runner-images/issues/5583
- https://endoflife.date/macos (Apple does not provide EOL information officially but no new 10.15.x release after macOS 10.15.7 security update 2022-005/2022-07-20)
  - [About the security content of Security Update 2022-005 Catalina - Apple Support](https://support.apple.com/en-us/102769) (2022-07-20)

All recent CI jobs on macOS 10.15 were failed due to timeout.

- e.g. https://github.com/bastibe/python-soundfile/actions/runs/6613147987/job/18360408635

> test (macos-10.15, 3.6, x64)
> This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.

We need to update macOS version to keep testing on CI.

## About macOS 11 and pypy 3.7 exclusion

macOS 11 and pypy 3.7 combination test remains disabled on this pull request.

macOS 10.15 and pypy 3.7 combination test was disabled due to compilation error.

- https://github.com/bastibe/python-soundfile/pull/327

It seems able to compile numpy 1.21.6 from source on macOS 11 and pypy 3.7 but the compilation of numpy takes a long time, 5 minutes 26 seconds.
So I keep it disabled but if you want to test it, please edit or mention it.

- https://github.com/aoirint/python-soundfile/actions/runs/6767519677/job/18390287961

<details>
<summary>CI log: pip install numpy pytest on macOS 11 and pypy 3.7</summary>

```shell
$ pip install numpy pytest
Collecting numpy
  Downloading numpy-1.21.6.zip (10.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.3/10.3 MB 26.9 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting pytest
  Downloading pytest-7.4.3-py3-none-any.whl.metadata (7.9 kB)
Collecting iniconfig (from pytest)
  Downloading iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
Collecting packaging (from pytest)
  Downloading packaging-23.2-py3-none-any.whl.metadata (3.2 kB)
Collecting pluggy<2.0,>=0.12 (from pytest)
  Downloading pluggy-1.2.0-py3-none-any.whl.metadata (4.4 kB)
Collecting exceptiongroup>=1.0.0rc8 (from pytest)
  Downloading exceptiongroup-1.1.3-py3-none-any.whl.metadata (6.1 kB)
Collecting tomli>=1.0.0 (from pytest)
  Downloading tomli-2.0.1-py3-none-any.whl (12 kB)
Collecting importlib-metadata>=0.12 (from pytest)
  Downloading importlib_metadata-6.7.0-py3-none-any.whl.metadata (4.9 kB)
Collecting zipp>=0.5 (from importlib-metadata>=0.12->pytest)
  Downloading zipp-3.15.0-py3-none-any.whl (6.8 kB)
Collecting typing-extensions>=3.6.4 (from importlib-metadata>=0.12->pytest)
  Downloading typing_extensions-4.7.1-py3-none-any.whl.metadata (3.1 kB)
Downloading pytest-7.4.3-py3-none-any.whl (325 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 325.1/325.1 kB 18.5 MB/s eta 0:00:00
Downloading exceptiongroup-1.1.3-py3-none-any.whl (14 kB)
Downloading importlib_metadata-6.7.0-py3-none-any.whl (22 kB)
Downloading pluggy-1.2.0-py3-none-any.whl (17 kB)
Downloading packaging-23.2-py3-none-any.whl (53 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 53.0/53.0 kB 6.3 MB/s eta 0:00:00
Downloading typing_extensions-4.7.1-py3-none-any.whl (33 kB)
Building wheels for collected packages: numpy
  Building wheel for numpy (pyproject.toml): started
  Building wheel for numpy (pyproject.toml): still running...
  Building wheel for numpy (pyproject.toml): still running...
  Building wheel for numpy (pyproject.toml): still running...
  Building wheel for numpy (pyproject.toml): finished with status 'done'
  Created wheel for numpy: filename=numpy-1.21.6-pp37-pypy37_pp73-macosx_11_0_x86_64.whl size=4859840 sha256=05e4a537f9ef545651d3bc011a5ff4bf31b7f34963c0c1e6e0d0f87bf7581248
  Stored in directory: /Users/runner/Library/Caches/pip/wheels/ab/24/3b/c73b1bc7595de80fdfbce45adbabdb203ee622715ca4d45ffe
Successfully built numpy
Installing collected packages: zipp, typing-extensions, tomli, packaging, numpy, iniconfig, exceptiongroup, importlib-metadata, pluggy, pytest
Successfully installed exceptiongroup-1.1.3 importlib-metadata-6.7.0 iniconfig-2.0.0 numpy-1.21.6 packaging-23.2 pluggy-1.2.0 pytest-7.4.3 tomli-2.0.1 typing-extensions-4.7.1 zipp-3.15.0

Notice:  A new release of pip is available: 22.0.4 -> 23.3.1
Notice:  To update, run: pip install --upgrade pip
```

</details>
