### PR TITLE
CI Error Workaround: Generate _soundfile.py before the package editable installation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Install requirements
         run: pip install numpy pytest
       - name: "Workaround: Generate _soundfile.py explicitly"
-        run: python soundfile_build.py
+        run: |
+          pip install cffi>=1.0
+          python soundfile_build.py
       - name: Install editable package
         run: pip install --editable . --verbose
       - name: Run tests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,6 +42,8 @@ jobs:
           architecture: ${{ matrix.architecture }}
       - name: Install requirements
         run: pip install numpy pytest
+      - name: "Workaround: Generate _soundfile.py explicitly"
+        run: python soundfile_build.py
       - name: Install editable package
         run: pip install --editable . --verbose
       - name: Run tests


### PR DESCRIPTION
Fix the CI error `ModuleNotFoundError: No module named '_soundfile'` on Python 3.7+.

Details: https://github.com/bastibe/python-soundfile/pull/420#issuecomment-1836425183

---

I guess I was mistaken in my perception that Windows + Python 3.11 has problems.
Instead, it seems that the Windows + pypy-3.8 test sometimes fails and sometimes succeeds.


- Succeeded test: https://github.com/aoirint/python-soundfile/actions/runs/7157130696/job/19487640731
- Failed test: https://github.com/aoirint/python-soundfile/actions/runs/7157094168/job/19487564694

Error message

```plain
Fatal error in the GIL or with locks: EnterNonRecursiveMutex(ms) [ffffffff,6]
```

It could be a pypy specific issue, but I am not familiar with it.
