### PR TITLE
Update build_wheels.py for aarch64 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, macos-11]
         python-version:
           - "3.6"
           - "3.7"
@@ -18,7 +18,7 @@ jobs:
           - "3.11"
           - "pypy-3.7"
           - "pypy-3.8"
-        architecture: ["x86", "x64"]
+        architecture: ["x86", "x64", "aarch64"]
         exclude:
           - os: macos-11 # No Numpy binary wheel
             python-version: "pypy-3.7"

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -3,7 +3,7 @@ import shutil
 
 architectures = dict(darwin=['x86_64', 'arm64'],
                      win32=['32bit', '64bit'],
-                     linux=['x86_64'],
+                     linux=['x86_64', 'aarch64'],
                      noplatform='noarch')
 
 def cleanup():


### PR DESCRIPTION
The attached file here fixes an issue using HuggingFace datasets requiring `soundfile` on aarch64.

I compiled on this branch (bastibe/aarchh64-build) using `linux_build.sh` on Grace Hopper, which requires aarch64. This generated libsndfile.so which I renamed to libsndfile_aarch64.so to match the others

Then, in [this line ](https://github.com/bastibe/python-soundfile/blob/master/build_wheels.py#L6)I added `'aarch64'` and built the whl as suggested `python setup.py bdist_wheel` followed by installing the `whl` with `pip install dist/soundfile-0.12.1-py2.py3-none-manylinux_2_17_aarch64.whl`

This file should just be added to the repo along with the others.