### PR TITLE
creating blocksize length output array in blocks reading if fill_value is set regardless of frames in file

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -1107,7 +1107,7 @@ class SoundFile(object):
         if out is None:
             if blocksize is None:
                 raise TypeError("One of {blocksize, out} must be specified")
-            out_size = min(blocksize, frames)
+            out_size = blocksize if fill_value is not None else min(blocksize, frames)
             out = self._create_empty_array(out_size, always_2d, dtype)
             copy_out = True
         else:

--- a/tests/test_soundfile.py
+++ b/tests/test_soundfile.py
@@ -403,15 +403,38 @@ def test_blocks_inplace_modification(file_stereo_r):
 
 
 def test_blocks_mono():
+    blocks = list(sf.blocks(filename_mono, blocksize=3, dtype='int16'))
+    assert_equal_list_of_arrays(blocks, [[0, 1, 2], [-2, -1]])
+
+
+def test_blocks_with_fill_value_mono():
     blocks = list(sf.blocks(filename_mono, blocksize=3, dtype='int16',
                             fill_value=0))
     assert_equal_list_of_arrays(blocks, [[0, 1, 2], [-2, -1, 0]])
+
+
+def test_blocks_with_overlap_and_fill_value_mono():
+    blocks = list(sf.blocks(filename_mono, blocksize=4, dtype='int16',
+                            overlap=2, fill_value=0))
+    assert_equal_list_of_arrays(blocks, [[0, 1, 2, -2], [2, -2, -1, 0]])
 
 
 def test_block_longer_than_file_with_overlap_mono():
     blocks = list(sf.blocks(filename_mono, blocksize=20, dtype='int16',
                             overlap=2))
     assert_equal_list_of_arrays(blocks, [[0, 1, 2, -2, -1]])
+
+
+def test_block_longer_than_file_with_fill_value_mono():
+    blocks = list(sf.blocks(filename_mono, blocksize=10, dtype='int16',
+                            fill_value=0))
+    assert_equal_list_of_arrays(blocks, [[0, 1, 2, -2, -1, 0, 0, 0, 0, 0]])
+
+
+def test_block_longer_than_file_with_overlap_and_fill_value_mono():
+    blocks = list(sf.blocks(filename_mono, blocksize=10, dtype='int16',
+                            overlap=2, fill_value=0))
+    assert_equal_list_of_arrays(blocks, [[0, 1, 2, -2, -1, 0, 0, 0, 0, 0]])
 
 
 def test_blocks_rplus(sf_stereo_rplus):


### PR DESCRIPTION
In a previous [PR](https://github.com/bastibe/python-soundfile/pull/446) fixing blocks reading for files shorter than the specified blocksize, a regression was introduced resulting that even if the `fill_value` was specified, at most as many frames were read as the file had instead of the blocksize with the padding used. In this PR we add a fix so that if the fill_value is specified (and the output array is not), we will create an output array of blocksize regardless if the file doesn't have as many frames. Also added more unit tests to cover all these cases.

The regression mentioned above is part of version `0.13.0` of soundfile. Suggestion is to create a new version `0.13.1` with this fix included.