### PR TITLE
Enable Windows Arm64 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,13 @@ if architecture0 is None:
     # _find_library('sndfile') fails:
     if sys.platform == 'win32':
         architecture0 = architecture()[0]  # 64bit or 32bit
+        if architecture0 == '64bit':
+            if 'arm' in machine().lower():
+                architecture0 = 'arm64'
+            else:
+                architecture0 = 'x64'
     else:
-        architecture0 = machine()  # x86_64 or arm64
+        architecture0 = machine()
 
 if platform == 'darwin':
     libname = 'libsndfile_' + architecture0 + '.dylib'

--- a/soundfile.py
+++ b/soundfile.py
@@ -158,12 +158,11 @@ try:  # packaged lib (in _soundfile_data which should be on python path)
     elif _sys.platform == 'win32':
         from platform import architecture as _architecture
         from platform import machine as _machine
-        # this check can not be completed correctly: for x64 binaries running on
-        # arm64 Windows report the same values as arm64 binaries. For now, neither
-        # numpy nor cffi are available for arm64, so we can safely assume we're
-        # in x86 land:
         if _architecture()[0] == '64bit':
-            _packaged_libname = 'libsndfile_x64.dll'
+            if _machine().lower() == 'arm64':
+                _packaged_libname = 'libsndfile_arm64.dll'  
+            else:     
+                _packaged_libname = 'libsndfile_x64.dll'
         elif _architecture()[0] == '32bit':
             _packaged_libname = 'libsndfile_x86.dll'
         else:


### PR DESCRIPTION
Added checks to make use of the available libsndfile.dll for windows on arm64.
Numpy and cffi can be pip installed on arm64, so this should be available too.
Needed for torchaudio support on WinArm64