### PR TITLE
python-soundfile: add 'license_notes.md' to wheel

### DIFF
--- a/licensing/license_notes.md
+++ b/licensing/license_notes.md
@@ -1,0 +1,98 @@
+# license notes
+
+The canonical python-soundfile repository is located [here](https://github.com/bastibe/python-soundfile).
+
+While python-soundfile itself is licensed under the
+[BSD-3-Clause](https://opensource.org/license/bsd-3-clause) license, it links
+against media libraries that are licensed under a mixture of LGPL and BSD
+licenses within [libsndfile](https://github.com/libsndfile/libsndfile). To help
+ensure compliance for each of these libraries, copyrights and links to the
+corresponding source code are included below.
+
+## libflac
+
+Copyright: 1994-2013, Free Software Foundation, Inc
+  2000-2009, Josh Coalson
+  2011-2025, Xiph.Org Foundation http://www.xiph.org/
+
+License: BSD-3-Clause
+
+Source: [here](https://github.com/xiph/flac)
+
+Note: FLAC is GFDL-1.3, GPL-2.0, LGPL-2.1, and BSD-3-Clause licensed for
+different components. We are only using the libFLAC component, which is
+BSD-3-Clause.
+
+## libmp3lame
+
+Copyright: 1998, Michael Cheng
+           1999-2001, Mark Taylor
+           1999-2002, Albert L. Faber
+           1999-2005, Takehiro Tominaga
+           1999-2007, The LAME Project
+           2000-2005, Alexander Leidinger
+           2000-2005, Elecard Ltd.
+           2000-2005, Gabriel Bouvigne
+           2000-2005, Marie Orlova
+           2000-2005, Peter Gubanov
+           2000-2005, Vitaly Ivanov
+           2000-2008, Gabriel Bouvigne
+           2000-2008, Robert Hegemann
+           2000, Don Melton
+           2000, Frank Klemm
+           2001-2002, Naoki Shibata
+           2001, John Dahlstrom
+           2001, Jonathan Dee
+           2001, Ralf Kempkens
+           2002, Per Bolmstedt
+           2003, Olcios
+
+License: LGPL-2+
+
+Source: [here](https://sourceforge.net/p/lame/svn/HEAD/tree/)
+
+## libmpg123
+
+Copyright:
+  1995-2025 by the mpg123 project
+  2008 Christian Weisgerber <naddy@openbsd.org>
+  2006-2007 by Zuxy Meng
+  2000-2002 David Olofson
+  1998 Fabrice Bellard
+  1997 Mikko Tommila
+
+License: LGPL-2.1
+
+Source: [here](https://www.mpg123.de/trunk/)
+
+## libogg
+
+Copyright: 1994-2025, the Xiph.Org Foundation http://www.xiph.org/
+
+License: BSD-3-Clause
+
+Source: [here](https://github.com/xiph/ogg)
+
+## libopus
+
+Copyright: 1994-2025, the Xiph.Org Foundation http://www.xiph.org/
+ 2001-2018, Skype Limited
+ 2001-2018, Octasic
+ 2001-2018, Jean-Marc Valin
+ 2001-2018, Timothy B. Terriberry
+ 2001-2018, CSIRO
+ 2001-2018, Gregory Maxwell
+ 2001-2018, Mark Borgerding
+ 2001-2018, Erik de Castro Lopo
+
+License: BSD-3-Clause
+
+Source: [here](https://github.com/xiph/opus)
+
+## libvorbis
+
+Copyright (C) 2002-2025 Xiph.Org Foundation
+
+License: BSD-3-Clause
+
+Source: [here](https://github.com/xiph/vorbis)

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ else:
     libname = None
 
 if libname and os.path.isdir('_soundfile_data'):
-    packages = ['_soundfile_data']
-    package_data = {'_soundfile_data': [libname, 'COPYING']}
+    packages = ['_soundfile_data', 'licensing']
+    package_data = {'_soundfile_data': [libname, 'COPYING'], 'licensing': ['license_notes.md']}
     zip_safe = False
 else:
     packages = None


### PR DESCRIPTION
Fixes: #470

python-soundfile links dynamically against libsndfile, which is a statically-linked library including its dependencies. Modify setup.py to include a new license_notes.md file containing licensing details for each of libsndfile's dependencies.