### PR TITLE
Add Windows ARM64 support in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, windows-11-arm, macos-latest]
         python-version:
           - "3.10"
           - "3.11"
@@ -17,7 +17,7 @@ jobs:
           - "3.14"
           - "pypy-3.10"
           - "pypy-3.11"
-        architecture: ["x86", "x64"]
+        architecture: ["x86", "x64", "arm64"]
         exclude:
           - os: macos-latest
             python-version: "3.10"
@@ -27,6 +27,22 @@ jobs:
             architecture: "x86"
           - os: windows-latest
             python-version: "pypy-3.10"
+          - os: windows-11-arm
+            python-version: "3.10"
+          - os: windows-latest
+            architecture: "arm64"
+          - os: ubuntu-latest
+            architecture: "arm64"
+          - os: macos-latest
+            architecture: "arm64"
+          - os: windows-11-arm
+            architecture: "x86"
+          - os: windows-11-arm
+            architecture: "x64"
+          - os: windows-11-arm
+            python-version: "pypy-3.10"
+          - os: windows-11-arm
+            python-version: "pypy-3.11"
 
     steps:
       - uses: actions/checkout@v2

--- a/soundfile.py
+++ b/soundfile.py
@@ -170,11 +170,10 @@ try:  # packaged lib (in _soundfile_data which should be on python path)
     elif _sys.platform == 'win32':
         from platform import architecture as _architecture
         from platform import machine as _machine
-        # this check can not be completed correctly: for x64 binaries running on
-        # arm64 Windows report the same values as arm64 binaries. For now, neither
-        # numpy nor cffi are available for arm64, so we can safely assume we're
-        # in x86 land:
-        if _architecture()[0] == '64bit':
+        _win_machine = _machine().lower()
+        if _win_machine in ('arm64', 'aarch64'):
+            _packaged_libname = 'libsndfile_arm64.dll'
+        elif _architecture()[0] == '64bit':
             _packaged_libname = 'libsndfile_x64.dll'
         elif _architecture()[0] == '32bit':
             _packaged_libname = 'libsndfile_x86.dll'


### PR DESCRIPTION
This PR introduces official support for Windows ARM64.

**Changes:**

-  Updated `soundfile.py` to correctly detect ARM64/AArch64 architectures on Windows and load the corresponding `libsndfile_arm64.dll.`
- Added `windows-11-arm` to the GitHub Actions matrix and included arm64 architecture across supported OS versions.