### PR TITLE
Fix sf_error(NULL) race condition under concurrent open failures

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -12,6 +12,7 @@ __version__ = "0.13.1"
 
 import os as _os
 import sys as _sys
+import threading as _threading
 import numpy.typing
 from os import SEEK_SET, SEEK_CUR, SEEK_END
 from ctypes.util import find_library as _find_library
@@ -1269,6 +1270,13 @@ class SoundFile(object):
             self._file = None
             _error_check(err)
 
+    # sf_error(NULL) returns a global (non-thread-safe) error code.
+    # When an sf_open* call fails (returns NULL), we must call
+    # sf_error(NULL) to retrieve the error code, but another thread
+    # may clear the global error between our open and our sf_error.
+    # This lock serialises the open+sf_error(NULL) pair to prevent that.
+    _open_lock = _threading.Lock()
+
     def _open(self, file, mode_int, closefd):
         """Call the appropriate sf_open*() function from libsndfile."""
         if isinstance(file, (_unicode, bytes)):
@@ -1284,18 +1292,26 @@ class SoundFile(object):
                     openfunction = _snd.sf_wchar_open
                 else:
                     file = file.encode(_sys.getfilesystemencoding())
-            file_ptr = openfunction(file, mode_int, self._info)
+            with self._open_lock:
+                file_ptr = openfunction(file, mode_int, self._info)
+                if file_ptr == _ffi.NULL:
+                    err = _snd.sf_error(file_ptr)
+                    raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
         elif isinstance(file, int):
-            file_ptr = _snd.sf_open_fd(file, mode_int, self._info, closefd)
+            with self._open_lock:
+                file_ptr = _snd.sf_open_fd(file, mode_int, self._info, closefd)
+                if file_ptr == _ffi.NULL:
+                    err = _snd.sf_error(file_ptr)
+                    raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
         elif _has_virtual_io_attrs(file, mode_int):
-            file_ptr = _snd.sf_open_virtual(self._init_virtual_io(file),
-                                            mode_int, self._info, _ffi.NULL)
+            with self._open_lock:
+                file_ptr = _snd.sf_open_virtual(self._init_virtual_io(file),
+                                                mode_int, self._info, _ffi.NULL)
+                if file_ptr == _ffi.NULL:
+                    err = _snd.sf_error(file_ptr)
+                    raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
         else:
             raise TypeError("Invalid file: {0!r}".format(self.name))
-        if file_ptr == _ffi.NULL:
-            # get the actual error code
-            err = _snd.sf_error(file_ptr)
-            raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
         if mode_int == _snd.SFM_WRITE:
             # Due to a bug in libsndfile version <= 1.0.25, frames != 0
             # when opening a named pipe in SFM_WRITE mode.

--- a/soundfile.py
+++ b/soundfile.py
@@ -1275,7 +1275,7 @@ class SoundFile(object):
     # sf_error(NULL) to retrieve the error code, but another thread
     # may clear the global error between our open and our sf_error.
     # This lock serialises the open+sf_error(NULL) pair to prevent that.
-    _open_lock = _threading.Lock()
+    _sf_error_lock = _threading.Lock()
 
     def _open(self, file, mode_int, closefd):
         """Call the appropriate sf_open*() function from libsndfile."""
@@ -1292,26 +1292,19 @@ class SoundFile(object):
                     openfunction = _snd.sf_wchar_open
                 else:
                     file = file.encode(_sys.getfilesystemencoding())
-            with self._open_lock:
-                file_ptr = openfunction(file, mode_int, self._info)
-                if file_ptr == _ffi.NULL:
-                    err = _snd.sf_error(file_ptr)
-                    raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
         elif isinstance(file, int):
-            with self._open_lock:
-                file_ptr = _snd.sf_open_fd(file, mode_int, self._info, closefd)
-                if file_ptr == _ffi.NULL:
-                    err = _snd.sf_error(file_ptr)
-                    raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
+            openfunction = lambda file, mode_int, info: _snd.sf_open_fd(file, mode_int, info, closefd)
         elif _has_virtual_io_attrs(file, mode_int):
-            with self._open_lock:
-                file_ptr = _snd.sf_open_virtual(self._init_virtual_io(file),
-                                                mode_int, self._info, _ffi.NULL)
-                if file_ptr == _ffi.NULL:
-                    err = _snd.sf_error(file_ptr)
-                    raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
+            openfunction = lambda file, mode_int, info: _snd.sf_open_virtual(self._init_virtual_io(file),
+                                            mode_int, info, _ffi.NULL)
         else:
             raise TypeError("Invalid file: {0!r}".format(self.name))
+
+        with self._sf_error_lock:
+            file_ptr = openfunction(file, mode_int, self._info)
+            if file_ptr == _ffi.NULL:
+                err = _snd.sf_error(file_ptr)
+                raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
         if mode_int == _snd.SFM_WRITE:
             # Due to a bug in libsndfile version <= 1.0.25, frames != 0
             # when opening a named pipe in SFM_WRITE mode.


### PR DESCRIPTION
Serialise each `sf_open*()` + `sf_error(NULL)` pair under a class-level lock so the global error state cannot be clobbered between the two calls when multiple threads fail concurrently.

### Problem

`sf_error(NULL)` reads a **global** (non-thread-safe) error variable in libsndfile. When multiple threads concurrently open unsupported formats (e.g. MP4 bytes via `sf_open_virtual`), one thread can clear the global error before another reads it. This produces `LibsndfileError` with `code=0` and the message `"(Garbled error message from libsndfile)"` instead of the correct error code.

See #479 for a full reproduction script.

### Verification

Before fix: 
400 concurrent attempts on MP4 bytes:
All codes seen: {0, 1}
Code 0 (race condition) count: 23

After fix:
same test:
All codes seen: {1}
Code 0 (race condition) count: 0

Normal read/write and concurrent reads of valid audio files are unaffected.