### PR TITLE
Overload read and blocks functions and methods

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -16,17 +16,35 @@ import threading as _threading
 from collections.abc import Generator
 from ctypes.util import find_library as _find_library
 from os import SEEK_CUR, SEEK_END, SEEK_SET
-from typing import Any, BinaryIO, Final, Literal, TypeAlias
+from typing import Any, BinaryIO, Final, Literal, TypeAlias, overload, TypedDict
 
 import numpy
-from typing_extensions import Self
+from numpy import ndarray, int16, int32, float32, float64
+from numpy.typing import NDArray
+from typing_extensions import Self, Unpack, TypeVar
 
 from _soundfile import ffi as _ffi
 
 FileDescriptorOrPath: TypeAlias = str | int | BinaryIO | _os.PathLike[Any]
-AudioData: TypeAlias = numpy.ndarray[tuple[int, ...], numpy.dtype[numpy.float32 | numpy.float64 | numpy.int32 | numpy.int16]]
-AudioData_2d: TypeAlias = numpy.ndarray[tuple[int, int], numpy.dtype[numpy.float32 | numpy.float64 | numpy.int32 | numpy.int16]]
-dtype_str: TypeAlias = Literal['float64', 'float32', 'int32', 'int16']
+AudioData: TypeAlias = NDArray[float32 | float64 | int16 | int32]
+AudioData_2d: TypeAlias = ndarray[tuple[int, int], numpy.dtype[float32 | float64 | int16 | int32]]
+_2d_float32: TypeAlias = ndarray[tuple[int, int], numpy.dtype[float32]]
+_2d_float64: TypeAlias = ndarray[tuple[int, int], numpy.dtype[float64]]
+_2d_int16: TypeAlias = ndarray[tuple[int, int], numpy.dtype[int16]]
+_2d_int32: TypeAlias = ndarray[tuple[int, int], numpy.dtype[int32]]
+
+T_ndarray = TypeVar('T_ndarray', bound=numpy.ndarray)
+
+dtype_str: TypeAlias = Literal['float32', 'float64', 'int16', 'int32']
+
+class kwargs_read(TypedDict, total=False):
+    samplerate: int | None
+    channels: int | None
+    format: str | None
+    subtype: str | None
+    endian: str | None
+    closefd: bool
+
 _snd: Any
 _ffi: Any
 
@@ -222,10 +240,47 @@ if __libsndfile_version__.startswith('libsndfile-'):
     __libsndfile_version__ = __libsndfile_version__[len('libsndfile-'):]
 
 
-def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None, dtype: dtype_str = 'float64',
-        always_2d: bool = False, fill_value: float | None = None, out: AudioData | AudioData_2d | None = None,
+@overload
+def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
+        dtype: dtype_str = 'float64', always_2d: bool = False, fill_value: float | None = None,
+        *, out: T_ndarray, **kwargs: Unpack[kwargs_read]) -> tuple[T_ndarray, int]:...
+@overload
+def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['float32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> tuple[_2d_float32, int]:...
+@overload
+def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['float32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> tuple[NDArray[float32], int]:...
+@overload
+def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
+        dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True], fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> tuple[_2d_float64, int]:...
+@overload
+def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
+        dtype: Literal['float64'] = 'float64', always_2d: bool = False, fill_value: float | None = None, out: None = None,
         samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
-        endian: str | None = None, closefd: bool = True) -> tuple[AudioData | AudioData_2d, int]:
+        endian: str | None = None, closefd: bool = True) -> tuple[NDArray[float64], int]:...
+@overload
+def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int16'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> tuple[_2d_int16, int]:...
+@overload
+def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int16'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> tuple[NDArray[int16], int]:...
+@overload
+def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> tuple[_2d_int32, int]:...
+@overload
+def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> tuple[NDArray[int32], int]:...
+def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None, dtype: dtype_str = 'float64',
+        always_2d: bool = False, fill_value: float | None = None, out: T_ndarray | None = None,
+        samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
+        endian: str | None = None, closefd: bool = True) -> tuple[AudioData | AudioData_2d | T_ndarray, int]:
 
     """Provide audio data from a sound file as NumPy array.
 
@@ -313,9 +368,8 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
     with SoundFile(file, 'r', samplerate, channels,
                    subtype, endian, format, closefd) as f:
         frames = f._prepare_read(start, stop, frames)
-        data = f.read(frames, dtype, always_2d, fill_value, out)
+        data = f.read(frames=frames, dtype=dtype, always_2d=always_2d, fill_value=fill_value, out=out)
     return data, f.samplerate
-
 
 
 def write(file: FileDescriptorOrPath, data: AudioData, samplerate: int,
@@ -377,14 +431,53 @@ def write(file: FileDescriptorOrPath, data: AudioData, samplerate: int,
                    compression_level, bitrate_mode) as f:
         f.write(data)
 
+
+@overload
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
+        frames: int = -1, start: int = 0, stop: int | None = None, dtype: dtype_str = 'float64',
+        always_2d: bool = False, fill_value: float | None = None,
+        *, out: T_ndarray, **kwargs: Unpack[kwargs_read]) -> Generator[T_ndarray]:...
+@overload
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['float32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> Generator[_2d_float32]:...
+@overload
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['float32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> Generator[NDArray[float32]]:...
+@overload
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
+        dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True], fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> Generator[_2d_float64]:...
+@overload
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
+        dtype: Literal['float64'] = 'float64', always_2d: bool = False, fill_value: float | None = None, out: None = None,
+        samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
+        endian: str | None = None, closefd: bool = True) -> Generator[NDArray[float64]]:...
+@overload
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int16'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> Generator[_2d_int16]:...
+@overload
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int16'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> Generator[NDArray[int16]]:...
+@overload
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> Generator[_2d_int32]:...
+@overload
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
+        **kwargs: Unpack[kwargs_read]) -> Generator[NDArray[int32]]:...
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None,
            overlap: int = 0, frames: int = -1, start: int = 0,
            stop: int | None = None, dtype: dtype_str = 'float64',
            always_2d: bool = False, fill_value: float | None = None,
-           out: AudioData | AudioData_2d | None = None, samplerate: int | None = None,
+           out: T_ndarray | None = None, samplerate: int | None = None,
            channels: int | None = None, format: str | None = None,
            subtype: str | None = None, endian: str | None = None,
-           closefd: bool = True) -> Generator[AudioData, None, None] | Generator[AudioData_2d, None, None]:
+           closefd: bool = True) -> Generator[AudioData] | Generator[AudioData_2d] | Generator[T_ndarray]:
     """Return a generator for block-wise reading.
 
     By default, iteration starts at the beginning and stops at the end
@@ -435,7 +528,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None,
     with SoundFile(file, 'r', samplerate, channels,
                    subtype, endian, format, closefd) as f:
         frames = f._prepare_read(start, stop, frames)
-        yield from f.blocks(blocksize, overlap, frames, dtype, always_2d, fill_value, out)
+        yield from f.blocks(blocksize=blocksize, overlap=overlap, frames=frames, dtype=dtype, always_2d=always_2d, fill_value=fill_value, out=out)
 
 
 class _SoundFileInfo:
@@ -871,10 +964,36 @@ class SoundFile:
         """Return the current read/write position."""
         return self.seek(0, SEEK_CUR)
 
-
+    @overload
+    def read(self, frames: int = -1, dtype: dtype_str = 'float64', always_2d: bool = False, fill_value: float | None = None,
+            *, out: T_ndarray) -> T_ndarray: ...
+    @overload
+    def read(self, frames: int = -1, *, dtype: Literal['float32'], always_2d: Literal[True],
+			fill_value: float | None = None, out: None = None) -> _2d_float32:...
+    @overload
+    def read(self, frames: int = -1, *, dtype: Literal['float32'], always_2d: bool = False,
+			fill_value: float | None = None, out: None = None) -> NDArray[float32]:...
+    @overload
+    def read(self, frames: int = -1, dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True],
+			fill_value: float | None = None, out: None = None) -> _2d_float64:...
+    @overload
+    def read(self, frames: int = -1, dtype: Literal['float64'] = 'float64', always_2d: bool = False,
+			fill_value: float | None = None, out: None = None) -> NDArray[float64]:...
+    @overload
+    def read(self, frames: int = -1, *, dtype: Literal['int16'], always_2d: Literal[True],
+			fill_value: float | None = None, out: None = None) -> _2d_int16:...
+    @overload
+    def read(self, frames: int = -1, *, dtype: Literal['int16'], always_2d: bool = False,
+            fill_value: float | None = None, out: None = None) -> NDArray[int16]:...
+    @overload
+    def read(self, frames: int = -1, *, dtype: Literal['int32'], always_2d: Literal[True],
+			fill_value: float | None = None, out: None = None) -> _2d_int32:...
+    @overload
+    def read(self, frames: int = -1, *, dtype: Literal['int32'], always_2d: bool = False,
+			fill_value: float | None = None, out: None = None) -> NDArray[int32]:...
     def read(self, frames: int = -1, dtype: dtype_str = 'float64',
             always_2d: bool = False, fill_value: float | None = None,
-            out: AudioData | AudioData_2d | None = None) -> AudioData | AudioData_2d:
+            out: T_ndarray | None = None) -> AudioData | AudioData_2d | T_ndarray:
         """Read from the file and return data as NumPy array.
 
         Reads the given number of frames in the given data format
@@ -955,18 +1074,18 @@ class SoundFile:
         """
         if out is None:
             frames = self._check_frames(frames, fill_value)
-            out = self._create_empty_array(frames, always_2d, dtype)
+            sound = self._create_empty_array(frames, always_2d, dtype)
         else:
+            sound = out
             if frames < 0 or frames > len(out):
                 frames = len(out)
-        frames = self._array_io('read', out, frames)
-        if len(out) > frames:
+        frames = self._array_io('read', sound, frames)
+        if len(sound) > frames:
             if fill_value is None:
-                out = out[:frames]
+                sound = sound[:frames]
             else:
-                out[frames:] = fill_value
-        return out
-
+                sound[frames:] = fill_value
+        return sound
 
     def buffer_read(self, frames: int = -1, dtype: dtype_str | None = None) -> memoryview:
         """Read from the file and return data as buffer object.
@@ -1117,10 +1236,37 @@ class SoundFile:
         assert written == frames
         self._update_frames(written)
 
+    @overload
+    def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: dtype_str = 'float64',
+            always_2d: bool = False, fill_value: float | None = None, *, out: T_ndarray) -> Generator[T_ndarray]: ...
+    @overload
+    def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['float32'],
+            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_float32]:...
+    @overload
+    def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['float32'],
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[float32]]:...
+    @overload
+    def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: Literal['float64'] = 'float64',
+            *, always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_float64]:...
+    @overload
+    def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: Literal['float64'] = 'float64',
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[float64]]:...
+    @overload
+    def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int16'],
+            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_int16]:...
+    @overload
+    def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int16'],
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[int16]]:...
+    @overload
+    def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int32'],
+            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_int32]:...
+    @overload
+    def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int32'],
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[int32]]:...
     def blocks(self, blocksize: int | None = None, overlap: int = 0,
                frames: int = -1, dtype: dtype_str = 'float64',
                always_2d: bool = False, fill_value: float | None = None,
-               out: AudioData | AudioData_2d | None = None) -> Generator[AudioData, None, None] | Generator[AudioData_2d, None, None]:
+               out: T_ndarray | None = None) -> Generator[AudioData] | Generator[AudioData_2d] | Generator[T_ndarray]:
         """Return a generator for block-wise reading.
 
         By default, the generator yields blocks of the given
@@ -1179,13 +1325,14 @@ class SoundFile:
             if blocksize is None:
                 raise TypeError("One of {blocksize, out} must be specified")
             out_size = blocksize if fill_value is not None else min(blocksize, frames)
-            out = self._create_empty_array(out_size, always_2d, dtype)
+            sound = self._create_empty_array(out_size, always_2d, dtype)
             copy_out = True
         else:
             if blocksize is not None:
                 raise TypeError(
                     "Only one of {blocksize, out} may be specified")
-            blocksize = len(out)
+            sound = out
+            blocksize = len(sound)
             copy_out = False
 
         overlap_memory = None
@@ -1194,21 +1341,21 @@ class SoundFile:
                 output_offset = 0
             else:
                 output_offset = len(overlap_memory)
-                out[:output_offset] = overlap_memory
+                sound[:output_offset] = overlap_memory
 
             toread = min(blocksize - output_offset, frames)
-            self.read(toread, dtype, always_2d, fill_value, out[output_offset:])
+            self.read(frames=toread, dtype=dtype, always_2d=always_2d, fill_value=fill_value, out=sound[output_offset:])
 
             if overlap:
                 if overlap_memory is None:
-                    overlap_memory = np.copy(out[-overlap:])
+                    overlap_memory = np.copy(sound[-overlap:])
                 else:
-                    overlap_memory[:] = out[-overlap:]
+                    overlap_memory[:] = sound[-overlap:]
 
             if blocksize > frames + overlap and fill_value is None:
-                block = out[:frames + overlap]
+                block = sound[:frames + overlap]
             else:
-                block = out
+                block = sound
             yield np.copy(block) if copy_out else block
             frames -= toread
 

--- a/soundfile.py
+++ b/soundfile.py
@@ -30,6 +30,10 @@ FileDescriptorOrPath: TypeAlias = str | int | BinaryIO | _os.PathLike[Any]
 
 dtype_str: TypeAlias = Literal['float32', 'float64', 'int16', 'int32']
 
+_dtypeT = TypeVar('_dtypeT', float32, float64, int16, int32, default=float64)
+
+_NDArray: TypeAlias = ndarray[tuple[Any, ...], np.dtype[_dtypeT]]
+
 AudioData: TypeAlias = NDArray[float32 | float64 | int16 | int32]
 AudioData_2d: TypeAlias = ndarray[tuple[int, int], np.dtype[float32 | float64 | int16 | int32]]
 _2d_float32: TypeAlias = ndarray[tuple[int, int], np.dtype[float32]]
@@ -253,7 +257,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['float32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[NDArray[float32], int]: ...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_NDArray[float32], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True], fill_value: float | None = None, out: None = None,
@@ -262,7 +266,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', always_2d: bool = False, fill_value: float | None = None, out: None = None,
         samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
-        endian: str | None = None, closefd: bool = True) -> tuple[NDArray[float64], int]: ...
+        endian: str | None = None, closefd: bool = True) -> tuple[_NDArray[float64], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
@@ -270,7 +274,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[NDArray[int16], int]: ...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_NDArray[int16], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
@@ -278,7 +282,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[NDArray[int32], int]: ...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_NDArray[int32], int]: ...
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None, dtype: dtype_str = 'float64',
         always_2d: bool = False, fill_value: float | None = None, out: _ndarrayT | None = None,
         samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
@@ -447,7 +451,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['float32'], always_2d: bool = False, fill_value: float | None = None,
-        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[NDArray[float32]]: ...
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_NDArray[float32]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -458,7 +462,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
         frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', always_2d: bool = False, fill_value: float | None = None, out: None = None,
         samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
-        endian: str | None = None, closefd: bool = True) -> Generator[NDArray[float64]]: ...
+        endian: str | None = None, closefd: bool = True) -> Generator[_NDArray[float64]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -468,7 +472,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: bool = False, fill_value: float | None = None,
-        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[NDArray[int16]]: ...
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_NDArray[int16]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -478,7 +482,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: bool = False, fill_value: float | None = None,
-        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[NDArray[int32]]: ...
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_NDArray[int32]]: ...
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None,
            overlap: int = 0, frames: int = -1, start: int = 0,
            stop: int | None = None, dtype: dtype_str = 'float64',
@@ -981,25 +985,25 @@ class SoundFile:
 			fill_value: float | None = None, out: None = None) -> _2d_float32: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['float32'], always_2d: bool = False,
-			fill_value: float | None = None, out: None = None) -> NDArray[float32]: ...
+			fill_value: float | None = None, out: None = None) -> _NDArray[float32]: ...
     @overload
     def read(self, frames: int = -1, dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True],
 			fill_value: float | None = None, out: None = None) -> _2d_float64: ...
     @overload
     def read(self, frames: int = -1, dtype: Literal['float64'] = 'float64', always_2d: bool = False,
-			fill_value: float | None = None, out: None = None) -> NDArray[float64]: ...
+			fill_value: float | None = None, out: None = None) -> _NDArray[float64]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int16'], always_2d: Literal[True],
 			fill_value: float | None = None, out: None = None) -> _2d_int16: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int16'], always_2d: bool = False,
-            fill_value: float | None = None, out: None = None) -> NDArray[int16]: ...
+            fill_value: float | None = None, out: None = None) -> _NDArray[int16]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int32'], always_2d: Literal[True],
 			fill_value: float | None = None, out: None = None) -> _2d_int32: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int32'], always_2d: bool = False,
-			fill_value: float | None = None, out: None = None) -> NDArray[int32]: ...
+			fill_value: float | None = None, out: None = None) -> _NDArray[int32]: ...
     def read(self, frames: int = -1, dtype: dtype_str = 'float64',
             always_2d: bool = False, fill_value: float | None = None,
             out: _ndarrayT | None = None) -> AudioData | AudioData_2d | _ndarrayT:
@@ -1253,25 +1257,25 @@ class SoundFile:
             always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_float32]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['float32'],
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[float32]]: ...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[float32]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: Literal['float64'] = 'float64',
             *, always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_float64]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: Literal['float64'] = 'float64',
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[float64]]: ...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[float64]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int16'],
             always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_int16]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int16'],
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[int16]]: ...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[int16]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int32'],
             always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_int32]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int32'],
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[int32]]: ...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[int32]]: ...
     def blocks(self, blocksize: int | None = None, overlap: int = 0,
                frames: int = -1, dtype: dtype_str = 'float64',
                always_2d: bool = False, fill_value: float | None = None,

--- a/soundfile.py
+++ b/soundfile.py
@@ -31,12 +31,8 @@ dtype_str: TypeAlias = Literal['float32', 'float64', 'int16', 'int32']
 _dtype: TypeAlias = float32 | float64 | int16 | int32
 _dtypeT = TypeVar('_dtypeT', float32, float64, int16, int32, _dtype, default=float64)
 
-_NDArray: TypeAlias = ndarray[tuple[Any, ...], np.dtype[_dtypeT]]
-
-AudioData: TypeAlias = _NDArray[_dtype]
+AudioData: TypeAlias = ndarray[tuple[Any, ...], np.dtype[_dtypeT]]
 AudioData_2d: TypeAlias = ndarray[tuple[int, int], np.dtype[_dtypeT]]
-
-_ndarrayT = TypeVar('_ndarrayT', bound=np.ndarray)
 
 _snd: Any
 _ffi: Any
@@ -244,7 +240,7 @@ if __libsndfile_version__.startswith('libsndfile-'):
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: dtype_str = 'float64', always_2d: bool = False, fill_value: float | None = None,
-        *, out: _ndarrayT, **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_ndarrayT, int]: ...
+        *, out: AudioData[_dtypeT], **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[AudioData[_dtypeT], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['float32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
@@ -252,7 +248,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['float32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_NDArray[float32], int]: ...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[AudioData[float32], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True], fill_value: float | None = None, out: None = None,
@@ -261,7 +257,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', always_2d: bool = False, fill_value: float | None = None, out: None = None,
         samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
-        endian: str | None = None, closefd: bool = True) -> tuple[_NDArray[float64], int]: ...
+        endian: str | None = None, closefd: bool = True) -> tuple[AudioData[float64], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
@@ -269,7 +265,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_NDArray[int16], int]: ...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[AudioData[int16], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
@@ -277,11 +273,11 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_NDArray[int32], int]: ...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[AudioData[int32], int]: ...
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None, dtype: dtype_str = 'float64',
-        always_2d: bool = False, fill_value: float | None = None, out: _ndarrayT | None = None,
+        always_2d: bool = False, fill_value: float | None = None, out: AudioData[Any] | None = None,
         samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
-        endian: str | None = None, closefd: bool = True) -> tuple[AudioData | AudioData_2d | _ndarrayT, int]:
+        endian: str | None = None, closefd: bool = True) -> tuple[AudioData[Any], int]:
     """Provide audio data from a sound file as NumPy array.
 
     By default, the whole file is read from the beginning, but the
@@ -436,7 +432,7 @@ def write(file: FileDescriptorOrPath, data: AudioData, samplerate: int,
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None, dtype: dtype_str = 'float64',
         always_2d: bool = False, fill_value: float | None = None,
-        *, out: _ndarrayT, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_ndarrayT]: ...
+        *, out: AudioData[_dtypeT], **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[AudioData[_dtypeT]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -446,7 +442,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['float32'], always_2d: bool = False, fill_value: float | None = None,
-        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_NDArray[float32]]: ...
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[AudioData[float32]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -457,7 +453,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
         frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', always_2d: bool = False, fill_value: float | None = None, out: None = None,
         samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
-        endian: str | None = None, closefd: bool = True) -> Generator[_NDArray[float64]]: ...
+        endian: str | None = None, closefd: bool = True) -> Generator[AudioData[float64]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -467,7 +463,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: bool = False, fill_value: float | None = None,
-        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_NDArray[int16]]: ...
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[AudioData[int16]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -477,15 +473,15 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: bool = False, fill_value: float | None = None,
-        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_NDArray[int32]]: ...
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[AudioData[int32]]: ...
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None,
            overlap: int = 0, frames: int = -1, start: int = 0,
            stop: int | None = None, dtype: dtype_str = 'float64',
            always_2d: bool = False, fill_value: float | None = None,
-           out: _ndarrayT | None = None, samplerate: int | None = None,
+           out: AudioData[Any] | None = None, samplerate: int | None = None,
            channels: int | None = None, format: str | None = None,
            subtype: str | None = None, endian: str | None = None,
-           closefd: bool = True) -> Generator[AudioData] | Generator[AudioData_2d] | Generator[_ndarrayT]:
+           closefd: bool = True) -> Generator[AudioData[Any]]:
     """Return a generator for block-wise reading.
 
     By default, iteration starts at the beginning and stops at the end
@@ -974,34 +970,34 @@ class SoundFile:
 
     @overload
     def read(self, frames: int = -1, dtype: dtype_str = 'float64', always_2d: bool = False, fill_value: float | None = None,
-            *, out: _ndarrayT) -> _ndarrayT: ...
+            *, out: AudioData[_dtypeT]) -> AudioData[_dtypeT]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['float32'], always_2d: Literal[True],
 			fill_value: float | None = None, out: None = None) -> AudioData_2d[float32]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['float32'], always_2d: bool = False,
-			fill_value: float | None = None, out: None = None) -> _NDArray[float32]: ...
+			fill_value: float | None = None, out: None = None) -> AudioData[float32]: ...
     @overload
     def read(self, frames: int = -1, dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True],
 			fill_value: float | None = None, out: None = None) -> AudioData_2d[float64]: ...
     @overload
     def read(self, frames: int = -1, dtype: Literal['float64'] = 'float64', always_2d: bool = False,
-			fill_value: float | None = None, out: None = None) -> _NDArray[float64]: ...
+			fill_value: float | None = None, out: None = None) -> AudioData[float64]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int16'], always_2d: Literal[True],
 			fill_value: float | None = None, out: None = None) -> AudioData_2d[int16]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int16'], always_2d: bool = False,
-            fill_value: float | None = None, out: None = None) -> _NDArray[int16]: ...
+            fill_value: float | None = None, out: None = None) -> AudioData[int16]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int32'], always_2d: Literal[True],
 			fill_value: float | None = None, out: None = None) -> AudioData_2d[int32]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int32'], always_2d: bool = False,
-			fill_value: float | None = None, out: None = None) -> _NDArray[int32]: ...
+			fill_value: float | None = None, out: None = None) -> AudioData[int32]: ...
     def read(self, frames: int = -1, dtype: dtype_str = 'float64',
             always_2d: bool = False, fill_value: float | None = None,
-            out: _ndarrayT | None = None) -> AudioData | AudioData_2d | _ndarrayT:
+            out: AudioData[Any] | None = None) -> AudioData[Any]:
         """Read from the file and return data as NumPy array.
 
         Reads the given number of frames in the given data format
@@ -1246,35 +1242,35 @@ class SoundFile:
 
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: dtype_str = 'float64',
-            always_2d: bool = False, fill_value: float | None = None, *, out: _ndarrayT) -> Generator[_ndarrayT]: ...
+            always_2d: bool = False, fill_value: float | None = None, *, out: AudioData[_dtypeT]) -> Generator[AudioData[_dtypeT]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['float32'],
             always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[AudioData_2d[float32]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['float32'],
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[float32]]: ...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[AudioData[float32]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: Literal['float64'] = 'float64',
             *, always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[AudioData_2d[float64]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: Literal['float64'] = 'float64',
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[float64]]: ...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[AudioData[float64]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int16'],
             always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[AudioData_2d[int16]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int16'],
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[int16]]: ...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[AudioData[int16]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int32'],
             always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[AudioData_2d[int32]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int32'],
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[int32]]: ...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[AudioData[int32]]: ...
     def blocks(self, blocksize: int | None = None, overlap: int = 0,
                frames: int = -1, dtype: dtype_str = 'float64',
                always_2d: bool = False, fill_value: float | None = None,
-               out: _ndarrayT | None = None) -> Generator[AudioData] | Generator[AudioData_2d] | Generator[_ndarrayT]:
+               out: AudioData[Any] | None = None) -> Generator[AudioData[Any]]:
         """Return a generator for block-wise reading.
 
         By default, the generator yields blocks of the given
@@ -1548,13 +1544,13 @@ class SoundFile:
             raise ValueError("Data size must be a multiple of frame size")
         return data, frames
 
-    def _create_empty_array(self, frames, always_2d, dtype):
+    def _create_empty_array(self, frames: int, always_2d: bool, dtype: dtype_str):
         """Create an empty array with appropriate shape."""
         import numpy as np
         if always_2d or self.channels > 1:
-            shape = frames, self.channels
+            shape = (frames, self.channels)
         else:
-            shape = frames,
+            shape = (frames,)
         return np.empty(shape, dtype, order='C')
 
     def _check_dtype(self, dtype):

--- a/soundfile.py
+++ b/soundfile.py
@@ -161,7 +161,7 @@ _default_subtypes: Final[dict[str, str]] = {
     'MP3':   'MPEG_LAYER_III',
 }
 
-_ffi_types: Final[dict[str, str]] = {
+_ffi_types: Final[dict[dtype_str, str]] = {
     'float64': 'double',
     'float32': 'float',
     'int32': 'int',
@@ -1553,14 +1553,14 @@ class SoundFile:
             shape = (frames,)
         return np.empty(shape, dtype, order='C')
 
-    def _check_dtype(self, dtype):
+    def _check_dtype(self, dtype) -> str:
         """Check if dtype string is valid and return ctype string."""
         try:
             return _ffi_types[dtype]
         except KeyError:
             raise ValueError(f"dtype must be one of {sorted(_ffi_types.keys())!r} and not {dtype!r}")
 
-    def _array_io(self, action, array, frames):
+    def _array_io(self, action, array: AudioData[Any], frames: int):
         """Check array and call low-level IO function."""
         if array.ndim not in (1,2):
             raise ValueError(f"Invalid shape: {array.shape!r} ({'0 dimensions not supported' if array.ndim < 1 else 'too many dimensions'})")

--- a/soundfile.py
+++ b/soundfile.py
@@ -21,7 +21,6 @@ from typing import (Any, BinaryIO, Final, Literal, TypeAlias, TypedDict,
 
 import numpy as np
 from numpy import float32, float64, int16, int32, ndarray
-from numpy.typing import NDArray
 from typing_extensions import Self, TypeVar, Unpack
 
 from _soundfile import ffi as _ffi
@@ -29,17 +28,13 @@ from _soundfile import ffi as _ffi
 FileDescriptorOrPath: TypeAlias = str | int | BinaryIO | _os.PathLike[Any]
 
 dtype_str: TypeAlias = Literal['float32', 'float64', 'int16', 'int32']
-
-_dtypeT = TypeVar('_dtypeT', float32, float64, int16, int32, default=float64)
+_dtype: TypeAlias = float32 | float64 | int16 | int32
+_dtypeT = TypeVar('_dtypeT', float32, float64, int16, int32, _dtype, default=float64)
 
 _NDArray: TypeAlias = ndarray[tuple[Any, ...], np.dtype[_dtypeT]]
 
-AudioData: TypeAlias = NDArray[float32 | float64 | int16 | int32]
-AudioData_2d: TypeAlias = ndarray[tuple[int, int], np.dtype[float32 | float64 | int16 | int32]]
-_2d_float32: TypeAlias = ndarray[tuple[int, int], np.dtype[float32]]
-_2d_float64: TypeAlias = ndarray[tuple[int, int], np.dtype[float64]]
-_2d_int16: TypeAlias = ndarray[tuple[int, int], np.dtype[int16]]
-_2d_int32: TypeAlias = ndarray[tuple[int, int], np.dtype[int32]]
+AudioData: TypeAlias = _NDArray[_dtype]
+AudioData_2d: TypeAlias = ndarray[tuple[int, int], np.dtype[_dtypeT]]
 
 _ndarrayT = TypeVar('_ndarrayT', bound=np.ndarray)
 
@@ -253,7 +248,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['float32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_2d_float32, int]: ...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[AudioData_2d[float32], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['float32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
@@ -261,7 +256,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_2d_float64, int]: ...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[AudioData_2d[float64], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', always_2d: bool = False, fill_value: float | None = None, out: None = None,
@@ -270,7 +265,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_2d_int16, int]: ...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[AudioData_2d[int16], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
@@ -278,7 +273,7 @@ def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_2d_int32, int]: ...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[AudioData_2d[int32], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
@@ -446,7 +441,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['float32'], always_2d: Literal[True], fill_value: float | None = None,
-        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_2d_float32]: ...
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[AudioData_2d[float32]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -456,7 +451,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True], fill_value: float | None = None,
-        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_2d_float64]: ...
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[AudioData_2d[float64]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -467,7 +462,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: Literal[True], fill_value: float | None = None,
-        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_2d_int16]: ...
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[AudioData_2d[int16]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -477,7 +472,7 @@ def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: in
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: Literal[True], fill_value: float | None = None,
-        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_2d_int32]: ...
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[AudioData_2d[int32]]: ...
 @overload
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None,
@@ -982,25 +977,25 @@ class SoundFile:
             *, out: _ndarrayT) -> _ndarrayT: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['float32'], always_2d: Literal[True],
-			fill_value: float | None = None, out: None = None) -> _2d_float32: ...
+			fill_value: float | None = None, out: None = None) -> AudioData_2d[float32]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['float32'], always_2d: bool = False,
 			fill_value: float | None = None, out: None = None) -> _NDArray[float32]: ...
     @overload
     def read(self, frames: int = -1, dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True],
-			fill_value: float | None = None, out: None = None) -> _2d_float64: ...
+			fill_value: float | None = None, out: None = None) -> AudioData_2d[float64]: ...
     @overload
     def read(self, frames: int = -1, dtype: Literal['float64'] = 'float64', always_2d: bool = False,
 			fill_value: float | None = None, out: None = None) -> _NDArray[float64]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int16'], always_2d: Literal[True],
-			fill_value: float | None = None, out: None = None) -> _2d_int16: ...
+			fill_value: float | None = None, out: None = None) -> AudioData_2d[int16]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int16'], always_2d: bool = False,
             fill_value: float | None = None, out: None = None) -> _NDArray[int16]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int32'], always_2d: Literal[True],
-			fill_value: float | None = None, out: None = None) -> _2d_int32: ...
+			fill_value: float | None = None, out: None = None) -> AudioData_2d[int32]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int32'], always_2d: bool = False,
 			fill_value: float | None = None, out: None = None) -> _NDArray[int32]: ...
@@ -1254,25 +1249,25 @@ class SoundFile:
             always_2d: bool = False, fill_value: float | None = None, *, out: _ndarrayT) -> Generator[_ndarrayT]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['float32'],
-            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_float32]: ...
+            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[AudioData_2d[float32]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['float32'],
             always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[float32]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: Literal['float64'] = 'float64',
-            *, always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_float64]: ...
+            *, always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[AudioData_2d[float64]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: Literal['float64'] = 'float64',
             always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[float64]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int16'],
-            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_int16]: ...
+            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[AudioData_2d[int16]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int16'],
             always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[int16]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int32'],
-            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_int32]: ...
+            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[AudioData_2d[int32]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int32'],
             always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[_NDArray[int32]]: ...

--- a/soundfile.py
+++ b/soundfile.py
@@ -16,37 +16,39 @@ import threading as _threading
 from collections.abc import Generator
 from ctypes.util import find_library as _find_library
 from os import SEEK_CUR, SEEK_END, SEEK_SET
-from typing import Any, BinaryIO, Final, Literal, TypeAlias, overload, TypedDict
+from typing import (Any, BinaryIO, Final, Literal, TypeAlias, TypedDict,
+                    overload)
 
-import numpy
-from numpy import ndarray, int16, int32, float32, float64
+import numpy as np
+from numpy import float32, float64, int16, int32, ndarray
 from numpy.typing import NDArray
-from typing_extensions import Self, Unpack, TypeVar
+from typing_extensions import Self, TypeVar, Unpack
 
 from _soundfile import ffi as _ffi
 
 FileDescriptorOrPath: TypeAlias = str | int | BinaryIO | _os.PathLike[Any]
-AudioData: TypeAlias = NDArray[float32 | float64 | int16 | int32]
-AudioData_2d: TypeAlias = ndarray[tuple[int, int], numpy.dtype[float32 | float64 | int16 | int32]]
-_2d_float32: TypeAlias = ndarray[tuple[int, int], numpy.dtype[float32]]
-_2d_float64: TypeAlias = ndarray[tuple[int, int], numpy.dtype[float64]]
-_2d_int16: TypeAlias = ndarray[tuple[int, int], numpy.dtype[int16]]
-_2d_int32: TypeAlias = ndarray[tuple[int, int], numpy.dtype[int32]]
-
-T_ndarray = TypeVar('T_ndarray', bound=numpy.ndarray)
 
 dtype_str: TypeAlias = Literal['float32', 'float64', 'int16', 'int32']
 
-class kwargs_read(TypedDict, total=False):
+AudioData: TypeAlias = NDArray[float32 | float64 | int16 | int32]
+AudioData_2d: TypeAlias = ndarray[tuple[int, int], np.dtype[float32 | float64 | int16 | int32]]
+_2d_float32: TypeAlias = ndarray[tuple[int, int], np.dtype[float32]]
+_2d_float64: TypeAlias = ndarray[tuple[int, int], np.dtype[float64]]
+_2d_int16: TypeAlias = ndarray[tuple[int, int], np.dtype[int16]]
+_2d_int32: TypeAlias = ndarray[tuple[int, int], np.dtype[int32]]
+
+_ndarrayT = TypeVar('_ndarrayT', bound=np.ndarray)
+
+_snd: Any
+_ffi: Any
+
+class _kwargs_read_blocks(TypedDict, total=False):
     samplerate: int | None
     channels: int | None
     format: str | None
     subtype: str | None
     endian: str | None
     closefd: bool
-
-_snd: Any
-_ffi: Any
 
 _str_types: Final[dict[str, int]] = {
     'title':       0x01,
@@ -243,45 +245,44 @@ if __libsndfile_version__.startswith('libsndfile-'):
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: dtype_str = 'float64', always_2d: bool = False, fill_value: float | None = None,
-        *, out: T_ndarray, **kwargs: Unpack[kwargs_read]) -> tuple[T_ndarray, int]:...
+        *, out: _ndarrayT, **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_ndarrayT, int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['float32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> tuple[_2d_float32, int]:...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_2d_float32, int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['float32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> tuple[NDArray[float32], int]:...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[NDArray[float32], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> tuple[_2d_float64, int]:...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_2d_float64, int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', always_2d: bool = False, fill_value: float | None = None, out: None = None,
         samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
-        endian: str | None = None, closefd: bool = True) -> tuple[NDArray[float64], int]:...
+        endian: str | None = None, closefd: bool = True) -> tuple[NDArray[float64], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> tuple[_2d_int16, int]:...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_2d_int16, int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int16'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> tuple[NDArray[int16], int]:...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[NDArray[int16], int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> tuple[_2d_int32, int]:...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[_2d_int32, int]: ...
 @overload
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None,
         *, dtype: Literal['int32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> tuple[NDArray[int32], int]:...
+        **kwargs: Unpack[_kwargs_read_blocks]) -> tuple[NDArray[int32], int]: ...
 def read(file: FileDescriptorOrPath, frames: int = -1, start: int = 0, stop: int | None = None, dtype: dtype_str = 'float64',
-        always_2d: bool = False, fill_value: float | None = None, out: T_ndarray | None = None,
+        always_2d: bool = False, fill_value: float | None = None, out: _ndarrayT | None = None,
         samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
-        endian: str | None = None, closefd: bool = True) -> tuple[AudioData | AudioData_2d | T_ndarray, int]:
-
+        endian: str | None = None, closefd: bool = True) -> tuple[AudioData | AudioData_2d | _ndarrayT, int]:
     """Provide audio data from a sound file as NumPy array.
 
     By default, the whole file is read from the beginning, but the
@@ -436,48 +437,56 @@ def write(file: FileDescriptorOrPath, data: AudioData, samplerate: int,
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
         frames: int = -1, start: int = 0, stop: int | None = None, dtype: dtype_str = 'float64',
         always_2d: bool = False, fill_value: float | None = None,
-        *, out: T_ndarray, **kwargs: Unpack[kwargs_read]) -> Generator[T_ndarray]:...
+        *, out: _ndarrayT, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_ndarrayT]: ...
 @overload
-def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
-        *, dtype: Literal['float32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> Generator[_2d_float32]:...
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
+        frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['float32'], always_2d: Literal[True], fill_value: float | None = None,
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_2d_float32]: ...
 @overload
-def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
-        *, dtype: Literal['float32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> Generator[NDArray[float32]]:...
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
+        frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['float32'], always_2d: bool = False, fill_value: float | None = None,
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[NDArray[float32]]: ...
 @overload
-def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
-        dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> Generator[_2d_float64]:...
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
+        frames: int = -1, start: int = 0, stop: int | None = None,
+        dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True], fill_value: float | None = None,
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_2d_float64]: ...
 @overload
-def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
+        frames: int = -1, start: int = 0, stop: int | None = None,
         dtype: Literal['float64'] = 'float64', always_2d: bool = False, fill_value: float | None = None, out: None = None,
         samplerate: int | None = None, channels: int | None = None, format: str | None = None, subtype: str | None = None,
-        endian: str | None = None, closefd: bool = True) -> Generator[NDArray[float64]]:...
+        endian: str | None = None, closefd: bool = True) -> Generator[NDArray[float64]]: ...
 @overload
-def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
-        *, dtype: Literal['int16'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> Generator[_2d_int16]:...
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
+        frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int16'], always_2d: Literal[True], fill_value: float | None = None,
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_2d_int16]: ...
 @overload
-def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
-        *, dtype: Literal['int16'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> Generator[NDArray[int16]]:...
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
+        frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int16'], always_2d: bool = False, fill_value: float | None = None,
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[NDArray[int16]]: ...
 @overload
-def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
-        *, dtype: Literal['int32'], always_2d: Literal[True], fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> Generator[_2d_int32]:...
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
+        frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int32'], always_2d: Literal[True], fill_value: float | None = None,
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[_2d_int32]: ...
 @overload
-def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0, frames: int = -1, start: int = 0, stop: int | None = None,
-        *, dtype: Literal['int32'], always_2d: bool = False, fill_value: float | None = None, out: None = None,
-        **kwargs: Unpack[kwargs_read]) -> Generator[NDArray[int32]]:...
+def blocks(file: FileDescriptorOrPath, blocksize: int | None = None, overlap: int = 0,
+        frames: int = -1, start: int = 0, stop: int | None = None,
+        *, dtype: Literal['int32'], always_2d: bool = False, fill_value: float | None = None,
+        out: None = None, **kwargs: Unpack[_kwargs_read_blocks]) -> Generator[NDArray[int32]]: ...
 def blocks(file: FileDescriptorOrPath, blocksize: int | None = None,
            overlap: int = 0, frames: int = -1, start: int = 0,
            stop: int | None = None, dtype: dtype_str = 'float64',
            always_2d: bool = False, fill_value: float | None = None,
-           out: T_ndarray | None = None, samplerate: int | None = None,
+           out: _ndarrayT | None = None, samplerate: int | None = None,
            channels: int | None = None, format: str | None = None,
            subtype: str | None = None, endian: str | None = None,
-           closefd: bool = True) -> Generator[AudioData] | Generator[AudioData_2d] | Generator[T_ndarray]:
+           closefd: bool = True) -> Generator[AudioData] | Generator[AudioData_2d] | Generator[_ndarrayT]:
     """Return a generator for block-wise reading.
 
     By default, iteration starts at the beginning and stops at the end
@@ -966,34 +975,34 @@ class SoundFile:
 
     @overload
     def read(self, frames: int = -1, dtype: dtype_str = 'float64', always_2d: bool = False, fill_value: float | None = None,
-            *, out: T_ndarray) -> T_ndarray: ...
+            *, out: _ndarrayT) -> _ndarrayT: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['float32'], always_2d: Literal[True],
-			fill_value: float | None = None, out: None = None) -> _2d_float32:...
+			fill_value: float | None = None, out: None = None) -> _2d_float32: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['float32'], always_2d: bool = False,
-			fill_value: float | None = None, out: None = None) -> NDArray[float32]:...
+			fill_value: float | None = None, out: None = None) -> NDArray[float32]: ...
     @overload
     def read(self, frames: int = -1, dtype: Literal['float64'] = 'float64', *, always_2d: Literal[True],
-			fill_value: float | None = None, out: None = None) -> _2d_float64:...
+			fill_value: float | None = None, out: None = None) -> _2d_float64: ...
     @overload
     def read(self, frames: int = -1, dtype: Literal['float64'] = 'float64', always_2d: bool = False,
-			fill_value: float | None = None, out: None = None) -> NDArray[float64]:...
+			fill_value: float | None = None, out: None = None) -> NDArray[float64]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int16'], always_2d: Literal[True],
-			fill_value: float | None = None, out: None = None) -> _2d_int16:...
+			fill_value: float | None = None, out: None = None) -> _2d_int16: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int16'], always_2d: bool = False,
-            fill_value: float | None = None, out: None = None) -> NDArray[int16]:...
+            fill_value: float | None = None, out: None = None) -> NDArray[int16]: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int32'], always_2d: Literal[True],
-			fill_value: float | None = None, out: None = None) -> _2d_int32:...
+			fill_value: float | None = None, out: None = None) -> _2d_int32: ...
     @overload
     def read(self, frames: int = -1, *, dtype: Literal['int32'], always_2d: bool = False,
-			fill_value: float | None = None, out: None = None) -> NDArray[int32]:...
+			fill_value: float | None = None, out: None = None) -> NDArray[int32]: ...
     def read(self, frames: int = -1, dtype: dtype_str = 'float64',
             always_2d: bool = False, fill_value: float | None = None,
-            out: T_ndarray | None = None) -> AudioData | AudioData_2d | T_ndarray:
+            out: _ndarrayT | None = None) -> AudioData | AudioData_2d | _ndarrayT:
         """Read from the file and return data as NumPy array.
 
         Reads the given number of frames in the given data format
@@ -1238,35 +1247,35 @@ class SoundFile:
 
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: dtype_str = 'float64',
-            always_2d: bool = False, fill_value: float | None = None, *, out: T_ndarray) -> Generator[T_ndarray]: ...
+            always_2d: bool = False, fill_value: float | None = None, *, out: _ndarrayT) -> Generator[_ndarrayT]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['float32'],
-            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_float32]:...
+            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_float32]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['float32'],
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[float32]]:...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[float32]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: Literal['float64'] = 'float64',
-            *, always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_float64]:...
+            *, always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_float64]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, dtype: Literal['float64'] = 'float64',
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[float64]]:...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[float64]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int16'],
-            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_int16]:...
+            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_int16]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int16'],
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[int16]]:...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[int16]]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int32'],
-            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_int32]:...
+            always_2d: Literal[True], fill_value: float | None = None, out: None = None) -> Generator[_2d_int32]: ...
     @overload
     def blocks(self, blocksize: int | None = None, overlap: int = 0, frames: int = -1, *, dtype: Literal['int32'],
-            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[int32]]:...
+            always_2d: bool = False, fill_value: float | None = None, out: None = None) -> Generator[NDArray[int32]]: ...
     def blocks(self, blocksize: int | None = None, overlap: int = 0,
                frames: int = -1, dtype: dtype_str = 'float64',
                always_2d: bool = False, fill_value: float | None = None,
-               out: T_ndarray | None = None) -> Generator[AudioData] | Generator[AudioData_2d] | Generator[T_ndarray]:
+               out: _ndarrayT | None = None) -> Generator[AudioData] | Generator[AudioData_2d] | Generator[_ndarrayT]:
         """Return a generator for block-wise reading.
 
         By default, the generator yields blocks of the given


### PR DESCRIPTION
1. `NDArray` type for compact typing of indeterminate axes.
2. `_2d_float64` TypeAlias, and three more, for compact typing of 2-axis ndarray.
3. `T_ndarray` TypeVar for `out` parameter because the ndarray assigned to `out` is the return type.
4. `kwargs_read` TypedDict for parameters after `out`: see notes below.
5. Use keyword names in calls to methods to help the static type checkers.
6. In `Generator` type, remove the optional `None` values.
7. In read and blocks methods, add identifer, `sound`, to help the static type checkers.
8. In each overload definition, the placement of the line breaks _might_ make it easier to see the patterns.
9. `out` overload is first because it's different, but maybe it should be last.
10. Then overload definitions sorted by the order of the parameters, dtype and always_2d, alphabetical in dtype.

## Unpack

If `**kwargs: Unpack...` were in the primary definition, the parameters in the typed dict would be keyword-only, of course. In the overload definitions, if a user wants to ensure they have the benefit of a static type checker, then they will need to treat some of the parameters in most of the overload definitions are keyword-only, including those in `Unpack`.

I didn't add `Unpack` to the overload definition that contains the default values for dtype, always_2d, and out. Therefore, for the default case, for the static type checkers, all parameters are positional-or-keyword. After explaining my "reason", the idea sounds pretty stupid.