### PR TITLE
Fixes platform selection on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -242,22 +242,22 @@ In the following example OGG is converted to WAV entirely in memory (without wri
 
 Controlling bitrate mode and compression level
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-For some audio formats, you can control the bitrate and compression level. 
+For some audio formats, you can control the bitrate and compression level.
 
-`compression_level` is a float between 0 and 1, with 1 being the highest compression, 
+`compression_level` is a float between 0 and 1, with 1 being the highest compression,
 and `bitrate_mode` is 'VARIABLE', 'CONSTANT', or 'AVERAGE'.
 
 .. code:: python
 
     import soundfile as sf
-    
+
     # for example, this uncompressed 5 minute wav file with 32 kHz sample rate is 18 Mb
-    data, samplerate = sf.read('5min_32kHz.wav') 
-    
+    data, samplerate = sf.read('5min_32kHz.wav')
+
     # maximum mp3 compression results in 1.1 Mb file, with either CONSTANT or VARIABLE bit rate
-    sf.write('max_compression_vbr.mp3', data, samplerate, bitrate_mode='VARIABLE', compression_level=.99) 
+    sf.write('max_compression_vbr.mp3', data, samplerate, bitrate_mode='VARIABLE', compression_level=.99)
     sf.write('max_compression_cbr.mp3', data, samplerate, bitrate_mode='CONSTANT', compression_level=.99)
-    
+
     # minimum mp3 compression results in 3.5 Mb file
     sf.write('min_compression_vbr.mp3', data, samplerate, bitrate_mode='VARIABLE', compression_level=0)
 
@@ -408,3 +408,13 @@ News
     Thank you, Brian McFee and Guy Illes
 
     - Fixed regression in blocks
+
+2026-06-06 V0.14.0 Bastian Bechtold
+    Thank you GesonAnko, Trevor Gamblin, Andreas Karatzas, Harish RS, Hunter Hogan
+
+    - Added type annotations
+    - Added Licensing note to wheel
+    - Fixed race condition when opening files concurrently
+    - Fixed regressions in test suite
+    - Removed support for Python <= 3.9
+    - Added ARM64 support for Windows

--- a/soundfile.py
+++ b/soundfile.py
@@ -164,18 +164,17 @@ try:  # packaged lib (in _soundfile_data which should be on python path)
         from platform import machine as _machine
         _packaged_libname = 'libsndfile_' + _machine() + '.dylib'
     elif _sys.platform == 'win32':
-        from platform import architecture as _architecture
-        from platform import machine as _machine
+        import sysconfig as _sysconfig
 
-        _win_machine = _machine().lower()
-        if _win_machine in ('arm64', 'aarch64'):
+        _win_machine = _sysconfig.get_platform()
+        if _win_machine == 'win-arm64':
             _packaged_libname = 'libsndfile_arm64.dll'
-        elif _architecture()[0] == '64bit':
+        elif _win_machine == 'win-amd64':
             _packaged_libname = 'libsndfile_x64.dll'
-        elif _architecture()[0] == '32bit':
+        elif _win_machine == 'win32':
             _packaged_libname = 'libsndfile_x86.dll'
         else:
-            raise OSError(f'no packaged library for Windows {_architecture()} {_machine()}')
+            raise OSError(f'no packaged library for Windows {_win_machine}')
     elif _sys.platform == 'linux':
         from platform import machine as _machine
         if _machine() in ["aarch64", "aarch64_be", "armv8b", "armv8l"]:

--- a/soundfile.py
+++ b/soundfile.py
@@ -8,7 +8,7 @@ Alternatively, sound files can be opened as `SoundFile` objects.
 For further information, see https://python-soundfile.readthedocs.io/.
 
 """
-__version__ = "0.13.1"
+__version__ = "0.14.0"
 
 import os as _os
 import sys as _sys


### PR DESCRIPTION
On Windows, we have three platforms available (all three running on an ARM64 machine):

|  | Intel 32 | AMD 64 | ARM 64 |
| --- | ------- | --------- | ------- |
| `sys.platform` | `'win32'` | `'win32'` | `'win32'` |
| `sys.version` | `'...32 bit (Intel)'` | `'...64 bit (AMD64)'` | `'...64 bit (ARM64)'` |
| `platform.architecture()[0]` | `'32bit'` | `'63bit'` | `'64bit'` |
| `platform.machine()` | `'ARM64'` | `'ARM64'` | `'ARM64'` |
| `sysconfig.get_platform()` | `'win32'` | `'win-amd64'` | `'win-arm64'` |

Previously, we relied upon `platform.machine`, which seems to work as long as you're running arm64 Python on an arm64 machine, and amd64 Python on an amd64 machine. It however fails if you're running amd64 Python on an arm64 machine.

With this PR, we use `sysconfig.get_platform` instead, which correctly identifies the runtime environment.